### PR TITLE
[FEAT] BaseNavigationbar 구현완료 (#17)

### DIFF
--- a/Flag-iOS/Flag-iOS/Application/SceneDelegate.swift
+++ b/Flag-iOS/Flag-iOS/Application/SceneDelegate.swift
@@ -18,11 +18,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         self.window = UIWindow(windowScene: windowScene)
         let navigationController = UINavigationController(rootViewController: OnboardingViewController())
-        navigationController.isNavigationBarHidden = true
         self.window?.rootViewController = navigationController
         self.window?.makeKeyAndVisible()
         // 다크 모드 해제
         window?.overrideUserInterfaceStyle = .light
+        // navi hidden처리
+        navigationController.isNavigationBarHidden = true
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/Flag-iOS/Flag-iOS/Application/SceneDelegate.swift
+++ b/Flag-iOS/Flag-iOS/Application/SceneDelegate.swift
@@ -23,7 +23,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // 다크 모드 해제
         window?.overrideUserInterfaceStyle = .light
         // navi hidden처리
-        navigationController.isNavigationBarHidden = true
+//        navigationController.isNavigationBarHidden = true
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/Flag-iOS/Flag-iOS/Global/Base/BaseUIViewController.swift
+++ b/Flag-iOS/Flag-iOS/Global/Base/BaseUIViewController.swift
@@ -26,7 +26,7 @@ class BaseUIViewController: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = .systemBackground
         
-//        setupNavigationBar()
+        setupNavigationBar()
         setUI()
         setLayout()
         addTarget()
@@ -39,16 +39,12 @@ class BaseUIViewController: UIViewController {
     
     func setLayout() {}
     
-//    func setupNavigationBar() {
-////        self.navigationController?.navigationBar.tintColor = .black
-////        self.navigationController?.navigationBar.topItem?.title = ""
-////        self.navigationItem.leftBarButtonItem = backButton
-//        navigationController?.navigationBar.tintColor = .blue
-//        navigationController?.navigationBar.barTintColor = .black
-//        let backButton: UIBarButtonItem = UIBarButtonItem()
-//        navigationController?.navigationBar.topItem?.backBarButtonItem = backButton
-//        navigationController?.navigationBar.titleTextAttributes = [.foregroundColor: UIColor.black, NSAttributedString.Key.font: UIFont.title1]
-//    }
+    func setupNavigationBar() {
+        self.navigationController?.navigationBar.tintColor = .black
+        self.navigationController?.navigationBar.topItem?.title = ""
+        self.navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.font: UIFont.head1]
+        self.navigationItem.leftBarButtonItem = backButton
+    }
     
     @objc
     func backButtonTapped() {

--- a/Flag-iOS/Flag-iOS/Global/Base/BaseUIViewController.swift
+++ b/Flag-iOS/Flag-iOS/Global/Base/BaseUIViewController.swift
@@ -27,10 +27,16 @@ class BaseUIViewController: UIViewController {
         view.backgroundColor = .systemBackground
         
         setupNavigationBar()
+        setupNavigationPopGesture()
         setUI()
         setLayout()
         addTarget()
         setDelegate()
+    }
+    
+    public override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        navigationController?.navigationBar.isHidden = true
     }
     
     // MARK: - Custom Method
@@ -40,16 +46,23 @@ class BaseUIViewController: UIViewController {
     func setLayout() {}
     
     func setupNavigationBar() {
-        self.navigationController?.navigationBar.tintColor = .black
-        self.navigationController?.navigationBar.topItem?.title = ""
-        self.navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.font: UIFont.head1]
-        self.navigationItem.leftBarButtonItem = backButton
+//        navigationController?.navigationBar.isHidden = true
+        navigationController?.navigationBar.tintColor = .black
+        navigationController?.navigationBar.topItem?.title = ""
+        navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.font: UIFont.head1]
+        navigationItem.leftBarButtonItem = backButton
+    }
+    
+    func setupNavigationPopGesture() {
+        navigationController?.interactivePopGestureRecognizer?.isEnabled = true
+        navigationController?.interactivePopGestureRecognizer?.delegate = nil
     }
     
     @objc
     func backButtonTapped() {
         self.navigationController?.popViewController(animated: true)
     }
+    
     
     // MARK: - Action Method
     

--- a/Flag-iOS/Flag-iOS/Global/Base/BaseUIViewController.swift
+++ b/Flag-iOS/Flag-iOS/Global/Base/BaseUIViewController.swift
@@ -13,12 +13,6 @@ class BaseUIViewController: UIViewController {
     
     // MARK: - UI Components
     
-    private lazy var backButton = UIBarButtonItem(
-            image: ImageLiterals.backButtonIcon,
-            style: .plain,
-            target: self,
-            action: #selector(backButtonTapped)
-        )
     
     // MARK: - Life Cycle
     
@@ -27,16 +21,10 @@ class BaseUIViewController: UIViewController {
         view.backgroundColor = .systemBackground
         
         setupNavigationBar()
-        setupNavigationPopGesture()
         setUI()
         setLayout()
         addTarget()
         setDelegate()
-    }
-    
-    public override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        navigationController?.navigationBar.isHidden = true
     }
     
     // MARK: - Custom Method
@@ -46,23 +34,12 @@ class BaseUIViewController: UIViewController {
     func setLayout() {}
     
     func setupNavigationBar() {
-//        navigationController?.navigationBar.isHidden = true
         navigationController?.navigationBar.tintColor = .black
-        navigationController?.navigationBar.topItem?.title = ""
         navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.font: UIFont.head1]
-        navigationItem.leftBarButtonItem = backButton
+        let backButton: UIBarButtonItem = UIBarButtonItem()
+        backButton.title = ""
+        navigationController?.navigationBar.topItem?.backBarButtonItem = backButton
     }
-    
-    func setupNavigationPopGesture() {
-        navigationController?.interactivePopGestureRecognizer?.isEnabled = true
-        navigationController?.interactivePopGestureRecognizer?.delegate = nil
-    }
-    
-    @objc
-    func backButtonTapped() {
-        self.navigationController?.popViewController(animated: true)
-    }
-    
     
     // MARK: - Action Method
     

--- a/Flag-iOS/Flag-iOS/Global/Extension/UIFont+.swift
+++ b/Flag-iOS/Flag-iOS/Global/Extension/UIFont+.swift
@@ -9,46 +9,46 @@ import UIKit
 
 extension UIFont {
     class var head1: UIFont {
-        return UIFont(name: "Apple SD Gothic Neo", size: 20)!
+        return UIFont(name: "AppleSDGothicNeo-Bold", size: 20)!
     }
     
     class var head2: UIFont {
-        return UIFont(name: "Apple SD Gothic Neo", size: 16)!
+        return UIFont(name: "AppleSDGothicNeo-Bold", size: 16)!
     }
     
     class var title1: UIFont {
-        return UIFont(name: "Apple SD Gothic Neo", size: 18)!
+        return UIFont(name: "AppleSDGothicNeo-SemiBold", size: 18)!
     }
     
     class var title2: UIFont {
-        return UIFont(name: "Apple SD Gothic Neo", size: 14)!
+        return UIFont(name: "AppleSDGothicNeo-SemiBold", size: 14)!
     }
     
     class var title3: UIFont {
-        return UIFont(name: "Apple SD Gothic Neo", size: 12)!
+        return UIFont(name: "AppleSDGothicNeo-SemiBold", size: 12)!
     }
     
     class var subTitle1: UIFont {
-        return UIFont(name: "Apple SD Gothic Neo", size: 18)!
+        return UIFont(name: "AppleSDGothicNeo-Medium", size: 18)!
     }
     
     class var subTitle2: UIFont {
-        return UIFont(name: "Apple SD Gothic Neo", size: 16)!
+        return UIFont(name: "AppleSDGothicNeo-Medium", size: 16)!
     }
     
     class var subTitle3: UIFont {
-        return UIFont(name: "Apple SD Gothic Neo", size: 14)!
+        return UIFont(name: "AppleSDGothicNeo-Medium", size: 14)!
     }
     
     class var body1: UIFont {
-        return UIFont(name: "Apple SD Gothic Neo", size: 16)!
+        return UIFont(name: "AppleSDGothicNeo-Regular", size: 16)!
     }
     
     class var body2: UIFont {
-        return UIFont(name: "Apple SD Gothic Neo", size: 12)!
+        return UIFont(name: "AppleSDGothicNeo-Regular", size: 12)!
     }
     
     class var body3: UIFont {
-        return UIFont(name: "Apple SD Gothic Neo", size: 10)!
+        return UIFont(name: "AppleSDGothicNeo-Regular", size: 10)!
     }
 }

--- a/Flag-iOS/Flag-iOS/Global/Literal/TextLiterals.swift
+++ b/Flag-iOS/Flag-iOS/Global/Literal/TextLiterals.swift
@@ -19,6 +19,7 @@ enum TextLiterals {
     
     static let signIn: String = "로그인"
     static let signUp: String = "회원가입"
+    static let signUpTitleText: String = "FLAG 가입하기"
     static let inputEmailText: String = "이메일을 입력해 주세요"
     static let inputPasswordText: String = "비밀번호를 입력해 주세요"
     static let resetPassword: String = "비밀번호 재설정"

--- a/Flag-iOS/Flag-iOS/Scenes/Onboarding/ViewControllers/OnboardingViewController.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Onboarding/ViewControllers/OnboardingViewController.swift
@@ -9,14 +9,11 @@ import Foundation
 import SnapKit
 
 class OnboardingViewController: BaseUIViewController {
-    
-    // MARK: - Properties
-    
+        
     // MARK: - UI Components
+    
     private let onboardingView = OnboardingView()
-    
-    // MARK: - Life Cycle
-    
+        
     // MARK: - Custom Method
     
     override func setUI() {

--- a/Flag-iOS/Flag-iOS/Scenes/Onboarding/ViewControllers/SignInViewController.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Onboarding/ViewControllers/SignInViewController.swift
@@ -16,19 +16,12 @@ class SignInViewController: BaseUIViewController {
     private let signInView = SignInView()
     
     // MARK: - Life Cycle
-//    override func viewWillAppear(_ animated: Bool) {
-//        super.viewWillAppear(animated)
-//        navigationController?.navigationBar.isHidden = false
-//        navigationController?.navigationBar.topItem?.title = TextLiterals.signIn
-//    }
 
     // MARK: - Custom Method
     
     override func setupNavigationBar() {
         super.setupNavigationBar()
-        navigationController?.isNavigationBarHidden = false
-        navigationController?.navigationBar.topItem?.title = TextLiterals.signIn
-
+        navigationItem.title = TextLiterals.signIn
     }
 
     override func setUI() {

--- a/Flag-iOS/Flag-iOS/Scenes/Onboarding/ViewControllers/SignInViewController.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Onboarding/ViewControllers/SignInViewController.swift
@@ -10,20 +10,27 @@ import SnapKit
 import UIKit
 
 class SignInViewController: BaseUIViewController {
-    
-    // MARK: - Properties
-    
+        
     // MARK: - UI Components
+    
     private let signInView = SignInView()
     
     // MARK: - Life Cycle
-    override func viewDidLoad() {
-        super.viewDidLoad()
-    }
+//    override func viewWillAppear(_ animated: Bool) {
+//        super.viewWillAppear(animated)
+//        navigationController?.navigationBar.isHidden = false
+//        navigationController?.navigationBar.topItem?.title = TextLiterals.signIn
+//    }
 
-    
     // MARK: - Custom Method
     
+    override func setupNavigationBar() {
+        super.setupNavigationBar()
+        navigationController?.isNavigationBarHidden = false
+        navigationController?.navigationBar.topItem?.title = TextLiterals.signIn
+
+    }
+
     override func setUI() {
         view.addSubviews(signInView)
     }

--- a/Flag-iOS/Flag-iOS/Scenes/Onboarding/ViewControllers/SignUpViewController.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Onboarding/ViewControllers/SignUpViewController.swift
@@ -18,9 +18,7 @@ class SignUpViewController: BaseUIViewController {
     
     override func setupNavigationBar() {
         super.setupNavigationBar()
-        
-        navigationController?.isNavigationBarHidden = false
-        navigationController?.navigationBar.topItem?.title = TextLiterals.signUpTitleText
+        navigationItem.title = TextLiterals.signUpTitleText
     }
     
     override func setUI() {

--- a/Flag-iOS/Flag-iOS/Scenes/Onboarding/ViewControllers/SignUpViewController.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Onboarding/ViewControllers/SignUpViewController.swift
@@ -9,15 +9,19 @@ import Foundation
 import SnapKit
 
 class SignUpViewController: BaseUIViewController {
-    
-    // MARK: - Properties
-    
+        
     // MARK: - UI Components
+    
     private let signUpView = SignUpView()
-    
-    // MARK: - Life Cycle
-    
+        
     // MARK: - Custom Method
+    
+    override func setupNavigationBar() {
+        super.setupNavigationBar()
+        
+        navigationController?.isNavigationBarHidden = false
+        navigationController?.navigationBar.topItem?.title = TextLiterals.signUpTitleText
+    }
     
     override func setUI() {
         view.addSubviews(signUpView)

--- a/Flag-iOS/Flag-iOS/Scenes/Onboarding/Views/SignInView.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Onboarding/Views/SignInView.swift
@@ -12,13 +12,7 @@ import SnapKit
 class SignInView: BaseUIView {
     
     // MARK: - UI Components
-    private let label: UILabel = {
-        let label = UILabel()
-        label.text = "로그인"
-        label.font = .head1
-        return label
-    }()
-    
+
     private let emailInputTextField: BaseUITextField = {
         let textField = BaseUITextField()
         textField.placeholder = TextLiterals.inputEmailText
@@ -68,8 +62,7 @@ class SignInView: BaseUIView {
         userInfoSettingStackView.addArrangedSubviews(resetPasswordButton,
                                                      separateLabel,
                                                      signUpButton)
-        self.addSubviews(label,
-                         emailInputTextField,
+        self.addSubviews(emailInputTextField,
                          passwordInputTextField,
                          signInButton,
                          userInfoSettingStackView)
@@ -77,10 +70,6 @@ class SignInView: BaseUIView {
     }
     
     override func setLayout() {
-        label.snp.makeConstraints {
-            $0.top.equalTo(safeAreaLayoutGuide).offset(5)
-            $0.centerX.equalToSuperview()
-        }
         emailInputTextField.snp.makeConstraints {
             $0.top.equalTo(self.safeAreaLayoutGuide).offset(161)
             $0.horizontalEdges.equalToSuperview().inset(25)

--- a/Flag-iOS/Flag-iOS/Scenes/Onboarding/Views/SignUpView.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Onboarding/Views/SignUpView.swift
@@ -12,12 +12,6 @@ import SnapKit
 class SignUpView: BaseUIView {
     
     // MARK: - UI Components
-    private let label: UILabel = {
-        let label = UILabel()
-        label.text = "Flag 가입하기"
-        label.font = .head1
-        return label
-    }()
     
     private let emailLabel: UILabel = {
         let label = UILabel()
@@ -64,8 +58,7 @@ class SignUpView: BaseUIView {
     // MARK: - Custom Method
     
     override func setUI() {
-        self.addSubviews(label,
-                         emailLabel,
+        self.addSubviews(emailLabel,
                          emailTextField,
                          passwordLabel,
                          passwordTextField,
@@ -75,10 +68,6 @@ class SignUpView: BaseUIView {
     }
     
     override func setLayout() {
-        label.snp.makeConstraints {
-            $0.top.equalTo(safeAreaLayoutGuide).offset(5)
-            $0.centerX.equalToSuperview()
-        }
         emailLabel.snp.makeConstraints {
             $0.top.equalTo(safeAreaLayoutGuide).offset(93)
             $0.leading.equalToSuperview().offset(25)


### PR DESCRIPTION
## [#17] FEAT : BaseNavigationbar 구현완료

## 🌱 what is this PR?

- BaseNavigationbar 구현하였습니다.
- UIFont+ 에 볼드체 추가해놓았습니다.

## 🌱 PR Point

- BaseViewController 에 `viewDidLoad`에서 실행되도록 구현하였습니다.
- 아래와 같이 override 하여 사용하시면 됩니다.
```
override func setupNavigationBar() {
  super.setupNavigationBar()
  navigationItem.title = TextLiterals.signIn
}
```



## 📸 Screenshot

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 네비바 | <img width="383" alt="스크린샷 2023-08-07 오후 7 06 26" src="https://github.com/flag-app/Flag-iOS/assets/102797359/3134ebfe-e9ef-4bf9-8bf5-9e45667062b5"> |

## 📮 관련 이슈

- Resolved: #17
