### PR TITLE
[#48] FEAT : 진행상황뷰 하프모달 구현

### DIFF
--- a/Flag-iOS/Flag-iOS.xcodeproj/project.pbxproj
+++ b/Flag-iOS/Flag-iOS.xcodeproj/project.pbxproj
@@ -59,7 +59,6 @@
 		E53586A42A82019A007D053D /* LoactionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E53586A32A82019A007D053D /* LoactionView.swift */; };
 		E53586A62A8201A1007D053D /* TimeScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E53586A52A8201A1007D053D /* TimeScrollView.swift */; };
 		E53586A92A820251007D053D /* FlagView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E53586A82A820251007D053D /* FlagView.swift */; };
-		E53586AC2A820284007D053D /* File.swift in Sources */ = {isa = PBXBuildFile; fileRef = E53586AB2A820284007D053D /* File.swift */; };
 		E54787432A88CF550097F2D2 /* MyPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E54787422A88CF550097F2D2 /* MyPageView.swift */; };
 		E54787452A88CF610097F2D2 /* HeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E54787442A88CF610097F2D2 /* HeaderView.swift */; };
 		E54787472A88D00D0097F2D2 /* FriendListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E54787462A88D00D0097F2D2 /* FriendListViewController.swift */; };
@@ -162,6 +161,7 @@
 			children = (
 				7B51C5582A61008A0016B418 /* Flag-iOS */,
 				7B51C5572A61008A0016B418 /* Products */,
+				E547874F2A8AFF480097F2D2 /* Recovered References */,
 			);
 			sourceTree = "<group>";
 		};
@@ -436,6 +436,14 @@
 			path = Model;
 			sourceTree = "<group>";
 		};
+		E547874F2A8AFF480097F2D2 /* Recovered References */ = {
+			isa = PBXGroup;
+			children = (
+				E53586AB2A820284007D053D /* File.swift */,
+			);
+			name = "Recovered References";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -568,9 +576,8 @@
 				E593AA9D2A7E299500FC918A /* FriendsViewController.swift in Sources */,
 				E53586A02A82017E007D053D /* FreindsView.swift in Sources */,
 				E593AAA12A7E2C4D00FC918A /* DatePickViewController.swift in Sources */,
-				E50CEE4B2A8776A600101E4B /* CustomTableViewCell.swift in Sources */,
 				E50CEE4B2A8776A600101E4B /* TimeListCell.swift in Sources */,
-				E53586AC2A820284007D053D /* File.swift in Sources */,
+				E50CEE4B2A8776A600101E4B /* TimeListCell.swift in Sources */,
 				E53586A92A820251007D053D /* FlagView.swift in Sources */,
 				7B51C55C2A61008A0016B418 /* SceneDelegate.swift in Sources */,
 				E593AA992A7E1F9500FC918A /* SetNameViewController.swift in Sources */,

--- a/Flag-iOS/Flag-iOS/Application/SceneDelegate.swift
+++ b/Flag-iOS/Flag-iOS/Application/SceneDelegate.swift
@@ -17,7 +17,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let windowScene = (scene as? UIWindowScene) else { return }
         self.window = UIWindow(windowScene: windowScene)
-        let navigationController = UINavigationController(rootViewController: FlagInfoViewController())
+        let navigationController = UINavigationController(rootViewController: ProgressViewController())
         self.window?.rootViewController = navigationController
         self.window?.makeKeyAndVisible()
         // 다크 모드 해제

--- a/Flag-iOS/Flag-iOS/Scenes/Flag/ViewCotrollers/ListViewController.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Flag/ViewCotrollers/ListViewController.swift
@@ -7,12 +7,14 @@
 
 import UIKit
 
+
 final class ListViewController: BaseUIViewController {
     
     // MARK: - Properties
     
     private let listView = ListView()
     var selectedCellIndex: Int? = nil
+    let progressViewController = ProgressViewController()
     
     // MARK: - UI Components
 
@@ -42,7 +44,9 @@ final class ListViewController: BaseUIViewController {
     @objc
     func tap() {
         print("tap")
+        
     }
+
     
     @objc
     func buttonTapped(_ sender: UIButton) {

--- a/Flag-iOS/Flag-iOS/Scenes/Flag/ViewCotrollers/ListViewController.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Flag/ViewCotrollers/ListViewController.swift
@@ -7,6 +7,9 @@
 
 import UIKit
 
+protocol ListViewControllerDelegate: AnyObject {
+    func didDismissModal(with information: Int?)
+}
 
 final class ListViewController: BaseUIViewController {
     
@@ -15,6 +18,7 @@ final class ListViewController: BaseUIViewController {
     private let listView = ListView()
     var selectedCellIndex: Int? = nil
     let progressViewController = ProgressViewController()
+    weak var delegate: ListViewControllerDelegate?
     
     // MARK: - UI Components
 
@@ -43,11 +47,10 @@ final class ListViewController: BaseUIViewController {
     
     @objc
     func tap() {
-        print("tap")
-        
+        delegate?.didDismissModal(with: selectedCellIndex)
+        dismiss(animated: true, completion: nil)
     }
 
-    
     @objc
     func buttonTapped(_ sender: UIButton) {
         guard let cell = sender.superview?.superview as? CustomTableViewCell,

--- a/Flag-iOS/Flag-iOS/Scenes/Flag/ViewCotrollers/ProgressViewController.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Flag/ViewCotrollers/ProgressViewController.swift
@@ -43,10 +43,10 @@ final class ProgressViewController: BaseUIViewController {
     
     // MARK: - Life Cycle
     
-    override func viewDidLoad() {
-            super.viewDidLoad()
-            presentModalViewController()
-        }
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        presentModalViewController() 
+    }
     
     // MARK: - Custom Method
     

--- a/Flag-iOS/Flag-iOS/Scenes/Flag/ViewCotrollers/ProgressViewController.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Flag/ViewCotrollers/ProgressViewController.swift
@@ -43,6 +43,11 @@ final class ProgressViewController: BaseUIViewController {
     
     // MARK: - Life Cycle
     
+    override func viewDidLoad() {
+            super.viewDidLoad()
+            presentModalViewController()
+        }
+    
     // MARK: - Custom Method
     
     override func setUI() {
@@ -60,7 +65,6 @@ final class ProgressViewController: BaseUIViewController {
     }
     
     override func addTarget() {
-        progressView.nextButton.addTarget(self, action: #selector(didTappedNextButton), for: .touchUpInside)
         progressView.modalButton.addTarget(self, action: #selector(presentModalBtnTap), for: .touchUpInside)
     }
     
@@ -73,25 +77,28 @@ final class ProgressViewController: BaseUIViewController {
     @objc
     func didTappedNextButton() {
         let homeVC = BaseTabBarController()
-        self.navigationController?.pushViewController(homeVC, animated: true)
+        navigationController?.pushViewController(homeVC, animated: true)
+    }
+
+    @objc
+    func presentModalBtnTap() {
+        presentModal()
     }
     
-    @objc
-    private func presentModalBtnTap() {
-        
+    func presentModal(){
         let vc = ListViewController()
-        
         vc.modalPresentationStyle = .pageSheet
-        
         if let sheet = vc.sheetPresentationController {
-            
             sheet.detents = [.medium(), .large()]
             sheet.delegate = self
             sheet.prefersGrabberVisible = true
-            
         }
-        
         present(vc, animated: true, completion: nil)
+    }
+    
+
+    private func presentModalViewController() {
+        presentModal()
     }
     
     func categorizeNumbers() {
@@ -104,17 +111,6 @@ final class ProgressViewController: BaseUIViewController {
         }
         let borderNumber = allUserNumber/5
         for (element, count) in frequencyDict {
-//            if count == 1 {
-//                one.append(element)
-//            } else if count == 2 {
-//                two.append(element)
-//            } else if count == 3 {
-//                three.append(element)
-//            }else if count == 4 {
-//                four.append(element)
-//            }else if count == 5 {
-//                five.append(element)
-//            }
             switch count{
             case 0...borderNumber: one.append(element)
             case borderNumber...borderNumber*2: two.append(element)

--- a/Flag-iOS/Flag-iOS/Scenes/Flag/ViewCotrollers/ProgressViewController.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Flag/ViewCotrollers/ProgressViewController.swift
@@ -45,7 +45,7 @@ final class ProgressViewController: BaseUIViewController {
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        presentModalViewController() 
+        presentModalViewController()
     }
     
     // MARK: - Custom Method
@@ -85,8 +85,10 @@ final class ProgressViewController: BaseUIViewController {
         presentModal()
     }
     
+    
     func presentModal(){
         let vc = ListViewController()
+        vc.delegate = self
         vc.modalPresentationStyle = .pageSheet
         if let sheet = vc.sheetPresentationController {
             sheet.detents = [.medium(), .large()]
@@ -222,5 +224,18 @@ extension ProgressViewController: UICollectionViewDelegate {
 
 extension ProgressViewController: UISheetPresentationControllerDelegate {
     func sheetPresentationControllerDidChangeSelectedDetentIdentifier(_ sheetPresentationController: UISheetPresentationController) {
+    }
+}
+
+extension ProgressViewController: ListViewControllerDelegate {
+    func didDismissModal(with information: Int?) {
+        if let info = information {
+            print("모달로부터 전달된 리스트: \(info)")
+        }
+        //살짝 에니메이션
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            let homeVC = BaseTabBarController()
+            self.navigationController?.pushViewController(homeVC, animated: true)
+        }
     }
 }

--- a/Flag-iOS/Flag-iOS/Scenes/Flag/Views/ProgressView.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Flag/Views/ProgressView.swift
@@ -56,9 +56,9 @@ final class ProgressView: BaseUIView {
         return stackview
     }()
     
-    lazy var modalButton: BaseFillButton = {
-        let button = BaseFillButton()
-        button.setTitle("나와라 모달!", for: .normal)
+    lazy var modalButton: BaseEmptyButton = {
+        let button = BaseEmptyButton()
+        button.setTitle("약속 리스트", for: .normal)
         button.isEnabled = true
         return button
     }()

--- a/Flag-iOS/Flag-iOS/Scenes/Flag/Views/ProgressView.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Flag/Views/ProgressView.swift
@@ -18,12 +18,6 @@ final class ProgressView: BaseUIView {
     
     let sectionCount = 14
     
-    lazy var nextButton: BaseFillButton = {
-        let button = BaseFillButton()
-        button.setTitle(TextLiterals.nextText, for: .normal)
-        button.isEnabled = true
-        return button
-    }()
     
     private let timeLabel: UILabel = {
         let label = UILabel()
@@ -79,7 +73,6 @@ final class ProgressView: BaseUIView {
                          collectionView,
                          indicatorImageView,
                          stackview,
-                         nextButton,
                          modalButton)
     }
     
@@ -92,13 +85,8 @@ final class ProgressView: BaseUIView {
             $0.top.equalTo(collectionView.snp.bottom).offset(10)
             $0.leading.equalToSuperview().offset(25)
         }
-        nextButton.snp.makeConstraints {
-            $0.bottom.equalTo(safeAreaLayoutGuide).inset(21)
-            $0.horizontalEdges.equalToSuperview().inset(25)
-            $0.height.equalTo(49)
-        }
         modalButton.snp.makeConstraints { make in
-            make.bottom.equalTo(nextButton.snp.top).offset(-40)
+            make.bottom.equalTo(safeAreaLayoutGuide).inset(21)
             make.horizontalEdges.equalToSuperview().inset(25)
             make.height.equalTo(49)
         }
@@ -106,7 +94,7 @@ final class ProgressView: BaseUIView {
             make.trailing.equalTo(safeAreaLayoutGuide).inset(10)
             make.leading.equalTo(safeAreaLayoutGuide).inset(20)
             make.top.equalTo(timeLabel.snp.bottom)
-            make.bottom.equalTo(nextButton.snp.top).offset(-160)
+            make.bottom.equalTo(modalButton.snp.top).offset(-160)
         }
         indicatorImageView.snp.makeConstraints { make in
             make.top.equalTo(safeAreaLayoutGuide).offset(40)


### PR DESCRIPTION
## [#48 ] FEAT : 진행상황뷰 하프모달 구현

## 🌱 what is this PR?

- 진행상황뷰에 진입했을때 바로 하프모달이 보이게 작업했습니다
- 모달 뷰에서 약속확정버튼을 클릭하면 모달이 닫아진뒤 진행상황뷰에서 push를 통해 화면전환됩니다

## 🌱 PR Point

- 하프모달에서 정보입력받고  delegate사용해 진행상황뷰컨으로 정보전달했습니다
-모달이 완전히 dismiss된후 push하기위해 딜레이를 좀 걸어놨습니다. 
- 모달버튼 임의로 디자인수정해서 넣어놨습니다.피그마 디자인에 기존버튼들과 다른 버튼으로 쓰여 통일하면 좋을거 같아 수정했습니다.피그마 디자인이 더 괜찮으면 수정하겠습니다^^

## 📸 Screenshot

|    구현 내용    |   
| :-------------: | 
![ezgif com-video-to-gif (5)](https://github.com/flag-app/Flag-iOS/assets/128443511/2a4cd612-cd8f-4354-9cf3-fb305d7c52cf)
 

## 📮 관련 이슈

- Resolved: #48 
