### PR TITLE
[FEAT] 약속 collectionViewcell 클릭 가능하도록 레이아웃 수정 (#39)

### DIFF
--- a/Flag-iOS/Flag-iOS/Application/SceneDelegate.swift
+++ b/Flag-iOS/Flag-iOS/Application/SceneDelegate.swift
@@ -17,7 +17,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let windowScene = (scene as? UIWindowScene) else { return }
         self.window = UIWindow(windowScene: windowScene)
-        let navigationController = UINavigationController(rootViewController: OnboardingViewController())
+        let navigationController = UINavigationController(rootViewController: BaseTabBarController())
 
         self.window?.rootViewController = navigationController
         self.window?.makeKeyAndVisible()

--- a/Flag-iOS/Flag-iOS/Application/SceneDelegate.swift
+++ b/Flag-iOS/Flag-iOS/Application/SceneDelegate.swift
@@ -17,7 +17,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let windowScene = (scene as? UIWindowScene) else { return }
         self.window = UIWindow(windowScene: windowScene)
-        let navigationController = UINavigationController(rootViewController: BaseTabBarController())
+        let navigationController = UINavigationController(rootViewController: OnboardingViewController())
 
         self.window?.rootViewController = navigationController
         self.window?.makeKeyAndVisible()

--- a/Flag-iOS/Flag-iOS/Global/Base/BaseTabBarController.swift
+++ b/Flag-iOS/Flag-iOS/Global/Base/BaseTabBarController.swift
@@ -45,7 +45,6 @@ class BaseTabBarController: UITabBarController {
         flagViewController.tabBarItem = setTabbarItem(title: TextLiterals.flag, image: ImageLiterals.flag, selectedImage: ImageLiterals.flagFill)
         flagPlusViewController.tabBarItem = setTabbarItem(title: TextLiterals.flagPlus, image: ImageLiterals.home, selectedImage: ImageLiterals.homeFill)
         myPageViewController.tabBarItem = setTabbarItem(title: TextLiterals.myPage, image: ImageLiterals.flex, selectedImage: ImageLiterals.flexFill)
-        
     }
     
     private func setTabbarItem(title: String, image: UIImage, selectedImage: UIImage) -> UITabBarItem {

--- a/Flag-iOS/Flag-iOS/Scenes/Flag/ViewCotrollers/FlagMain/FlagViewController.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Flag/ViewCotrollers/FlagMain/FlagViewController.swift
@@ -144,13 +144,7 @@ extension FlagViewController: HomeMenuBarDelegate {
     }
 }
 
-//extension FlagViewController: FlagCollectionViewCellDelegate {
-//    func didSelectRowInFlagCollectionViewCell(isConfirmed: Bool) {
-//        print("DDDDDDDDDDDD")
-//        let vc = FlagInfoViewController()
-//        self.navigationController?.pushViewController(vc, animated: true)
-//    }
-//}
+// MARK: - FlagCollectionViewCellDelegate
 
 extension FlagViewController: FlagCollectionViewCellDelegate {
     

--- a/Flag-iOS/Flag-iOS/Scenes/Flag/ViewCotrollers/FlagMain/FlagViewController.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Flag/ViewCotrollers/FlagMain/FlagViewController.swift
@@ -159,6 +159,7 @@ extension FlagViewController: FlagCollectionViewCellDelegate {
     func cellForRow(at indexPath: IndexPath, in tableView: UITableView) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: FlagTableViewCell.identifier,
                                                  for: indexPath)
+        cell.selectionStyle = .none
         return cell
     }
     

--- a/Flag-iOS/Flag-iOS/Scenes/Flag/ViewCotrollers/FlagMain/FlagViewController.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Flag/ViewCotrollers/FlagMain/FlagViewController.swift
@@ -85,7 +85,8 @@ extension FlagViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView,
                         cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: FlagCollectionViewCell.identifier,
-                                                      for: indexPath)
+                                                      for: indexPath) as! FlagCollectionViewCell
+        cell.delegate = self
         return cell
     }
 }
@@ -143,9 +144,31 @@ extension FlagViewController: HomeMenuBarDelegate {
     }
 }
 
+//extension FlagViewController: FlagCollectionViewCellDelegate {
+//    func didSelectRowInFlagCollectionViewCell(isConfirmed: Bool) {
+//        print("DDDDDDDDDDDD")
+//        let vc = FlagInfoViewController()
+//        self.navigationController?.pushViewController(vc, animated: true)
+//    }
+//}
+
 extension FlagViewController: FlagCollectionViewCellDelegate {
-    func didSelectRowInFlagCollectionViewCell(isConfirmed: Bool) {
-        print("DDDDDDDDDDDD")
+    
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return 3
+    }
+    
+    func numberOfRows(in tableView: UITableView) -> Int {
+        return 1
+    }
+    
+    func cellForRow(at indexPath: IndexPath, in tableView: UITableView) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: FlagTableViewCell.identifier,
+                                                 for: indexPath)
+        return cell
+    }
+    
+    func didSelectRowAt(at indexPath: IndexPath, in tableView: UITableView) {
         let vc = FlagInfoViewController()
         self.navigationController?.pushViewController(vc, animated: true)
     }

--- a/Flag-iOS/Flag-iOS/Scenes/Flag/ViewCotrollers/FlagMain/FlagViewController.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Flag/ViewCotrollers/FlagMain/FlagViewController.swift
@@ -12,8 +12,6 @@ final class FlagViewController: BaseUIViewController {
     
     // MARK: - Properties
     
-    let cellId = "cellId"
-
     private var currentIndex: Int = 0 {
            didSet {
                changeItem(index: currentIndex)
@@ -103,9 +101,7 @@ extension FlagViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView,
                         layout collectionViewLayout: UICollectionViewLayout,
                         sizeForItemAt indexPath: IndexPath) -> CGSize {
-        // FIXME: 레이아웃 수정 필요
-    
-        return CGSize(width: view.frame.width, height: 680)
+        return CGSize(width: view.frame.width, height: view.safeAreaLayoutGuide.layoutFrame.height - flagView.menuBar.frame.height)
     }
     
     func collectionView(_ collectionView: UICollectionView,

--- a/Flag-iOS/Flag-iOS/Scenes/Flag/ViewCotrollers/FlagMain/FlagViewController.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Flag/ViewCotrollers/FlagMain/FlagViewController.swift
@@ -155,11 +155,12 @@ extension FlagViewController: FlagCollectionViewCellDelegate {
     func cellForRow(at indexPath: IndexPath, in tableView: UITableView) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: FlagTableViewCell.identifier,
                                                  for: indexPath)
-        cell.selectionStyle = .none
         return cell
     }
     
     func didSelectRowAt(at indexPath: IndexPath, in tableView: UITableView) {
+        tableView.deselectRow(at: indexPath, animated: true)
+
         let vc = FlagInfoViewController()
         self.navigationController?.pushViewController(vc, animated: true)
     }

--- a/Flag-iOS/Flag-iOS/Scenes/Flag/Views/FlagMain/FlagCollectionViewCell.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Flag/Views/FlagMain/FlagCollectionViewCell.swift
@@ -7,9 +7,17 @@
 
 import UIKit
 
+//protocol FlagCollectionViewCellDelegate: AnyObject {
+//    func didSelectRowInFlagCollectionViewCell(isConfirmed: Bool)
+//}
+
 protocol FlagCollectionViewCellDelegate: AnyObject {
-    func didSelectRowInFlagCollectionViewCell(isConfirmed: Bool)
+    func numberOfSections(in tableView: UITableView) -> Int
+    func numberOfRows(in tableView: UITableView) -> Int
+    func cellForRow(at indexPath: IndexPath, in tableView: UITableView) -> UITableViewCell
+    func didSelectRowAt(at indexPath: IndexPath, in tableView: UITableView)
 }
+
 
 class FlagCollectionViewCell: BaseCollectionViewCell {
     
@@ -64,22 +72,19 @@ class FlagCollectionViewCell: BaseCollectionViewCell {
 
 extension FlagCollectionViewCell: UITableViewDataSource {
     func numberOfSections(in tableView: UITableView) -> Int {
-        return 3
+        return delegate?.numberOfSections(in: tableView) ?? 0
     }
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 1
+        return delegate?.numberOfRows(in: tableView) ?? 0
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: FlagTableViewCell.identifier,
-                                                 for: indexPath)
-        return cell
+        return delegate?.cellForRow(at: indexPath, in: tableView) ?? FlagTableViewCell()
     }
 }
 
 extension FlagCollectionViewCell: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        print("didSelectRowAt")
-        delegate?.didSelectRowInFlagCollectionViewCell(isConfirmed: true)
+        delegate?.didSelectRowAt(at: indexPath, in: tableView)
     }
 }

--- a/Flag-iOS/Flag-iOS/Scenes/Flag/Views/FlagMain/FlagCollectionViewCell.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Flag/Views/FlagMain/FlagCollectionViewCell.swift
@@ -7,17 +7,12 @@
 
 import UIKit
 
-//protocol FlagCollectionViewCellDelegate: AnyObject {
-//    func didSelectRowInFlagCollectionViewCell(isConfirmed: Bool)
-//}
-
 protocol FlagCollectionViewCellDelegate: AnyObject {
     func numberOfSections(in tableView: UITableView) -> Int
     func numberOfRows(in tableView: UITableView) -> Int
     func cellForRow(at indexPath: IndexPath, in tableView: UITableView) -> UITableViewCell
     func didSelectRowAt(at indexPath: IndexPath, in tableView: UITableView)
 }
-
 
 class FlagCollectionViewCell: BaseCollectionViewCell {
     
@@ -70,6 +65,8 @@ class FlagCollectionViewCell: BaseCollectionViewCell {
     }
 }
 
+// MARK: - UITableViewDataSource
+
 extension FlagCollectionViewCell: UITableViewDataSource {
     func numberOfSections(in tableView: UITableView) -> Int {
         return delegate?.numberOfSections(in: tableView) ?? 0
@@ -82,6 +79,8 @@ extension FlagCollectionViewCell: UITableViewDataSource {
         return delegate?.cellForRow(at: indexPath, in: tableView) ?? FlagTableViewCell()
     }
 }
+
+// MARK: - UITableViewDelegate
 
 extension FlagCollectionViewCell: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/Flag-iOS/Flag-iOS/Scenes/Flag/Views/FlagMain/FlagView.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Flag/Views/FlagMain/FlagView.swift
@@ -42,7 +42,7 @@ final class FlagView: BaseUIView {
         flagCollectionView.snp.makeConstraints {
             $0.top.equalTo(menuBar.snp.bottom)
             $0.horizontalEdges.equalToSuperview()
-            $0.bottom.equalToSuperview()
+            $0.bottom.equalTo(safeAreaLayoutGuide)
         }
     }
 }

--- a/Flag-iOS/Flag-iOS/Scenes/Flag/Views/FlagMain/FlagView.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Flag/Views/FlagMain/FlagView.swift
@@ -30,7 +30,6 @@ final class FlagView: BaseUIView {
     override func setUI() {
         addSubviews(menuBar,
                     flagCollectionView)
-
     }
 
     override func setLayout() {
@@ -43,6 +42,9 @@ final class FlagView: BaseUIView {
             $0.top.equalTo(menuBar.snp.bottom)
             $0.horizontalEdges.equalToSuperview()
             $0.bottom.equalTo(safeAreaLayoutGuide)
+        }
+        menuBar.menuHorizontalBarView.snp.makeConstraints {
+            $0.width.equalToSuperview().multipliedBy(0.5)
         }
     }
 }

--- a/Flag-iOS/Flag-iOS/Scenes/Flag/Views/FlagMain/MainMenuBar.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Flag/Views/FlagMain/MainMenuBar.swift
@@ -66,9 +66,7 @@ class MainMenuBar: BaseUIView {
             $0.edges.equalToSuperview()
         }
         menuHorizontalBarView.snp.makeConstraints {
-            $0.leading.equalToSuperview().offset(36)
-            $0.bottom.equalToSuperview()
-            $0.width.equalTo(170)
+            $0.leading.bottom.equalToSuperview()
             $0.height.equalTo(3)
         }
     }


### PR DESCRIPTION
## [#39] FEAT : 약속 collectionViewcell 클릭 가능하도록 레이아웃 수정

## 🌱 what is this PR?

- flag 메인 뷰의 전체적인 레이아웃 수정하였습니다.
- flag cell 클릭 시, 상세보기 뷰로 넘어갑니다.

## 🌱 PR Point

- 이전에 같이 고민했던 collectionViewCell에 tableView를 올려 tableViewCell이 클릭되었을 때, VC의 푸시가 안 되는 점 해결했습니다.
   - MVC 패턴을 생각해보았을 때, 사용자의 클릭 이벤트를 `View`에서 받아와 `Model`에서 정보를 업데이트하여 다시 View에게 보여주는 것이 Controller의 역할이라고 생각했습니다. 결정적으론 navigationController가 존재하는 Controller에서만 push가 가능하기에 `tableViewCell`의 `DataSource/Delegate`를 Controller에서 지정하려했고, VC에서 tableViewCell을 찾아가지 못해 delegate를 통해 전달하였습니다. 깔끔한 방법은 아닌 것 같기에... 계속 고민해보면서 리팩터링 해볼께요!
   - 추가로 이전 pr에서 superview를 찾아가는 코드를 보고, 아래와 같이 subview를 찾아가는 방법으로 적용해보았는데 log에 아무것도 안 찍히네요... 더 공부해보겠습니다
```
   for subview in flagView.flagCollectionView.subviews {
            print(subview)
        }
```

- 진행 / 확정 분기처리는 다음 작업으로 바로 진행할께요~

## 📸 Screenshot

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| flag 메인 |![ezgif com-video-to-gif (10)](https://github.com/flag-app/Flag-iOS/assets/102797359/47380742-4b9b-4ec3-87e2-7e6a1c807ad0) |


## 📮 관련 이슈

- Resolved: #39
