### PR TITLE
[FEAT] user 친구 추가 목록 localDB 관리하기 (#65)

### DIFF
--- a/Flag-iOS/Flag-iOS.xcodeproj/project.pbxproj
+++ b/Flag-iOS/Flag-iOS.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		7B31F7FA2A8E7D8300D7D0CF /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = 7B31F7F92A8E7D8300D7D0CF /* Realm */; };
 		7B31F7FC2A8E7D8300D7D0CF /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 7B31F7FB2A8E7D8300D7D0CF /* RealmSwift */; };
+		7B31F8002A8E7E6700D7D0CF /* UserFriendListDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B31F7FF2A8E7E6700D7D0CF /* UserFriendListDTO.swift */; };
+		7B31F8022A8E7EB900D7D0CF /* testRealmViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B31F8012A8E7EB900D7D0CF /* testRealmViewController.swift */; };
 		7B51C55A2A61008A0016B418 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B51C5592A61008A0016B418 /* AppDelegate.swift */; };
 		7B51C55C2A61008A0016B418 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B51C55B2A61008A0016B418 /* SceneDelegate.swift */; };
 		7B51C5632A61008C0016B418 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7B51C5622A61008C0016B418 /* Assets.xcassets */; };
@@ -80,6 +82,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		7B31F7FF2A8E7E6700D7D0CF /* UserFriendListDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFriendListDTO.swift; sourceTree = "<group>"; };
+		7B31F8012A8E7EB900D7D0CF /* testRealmViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = testRealmViewController.swift; sourceTree = "<group>"; };
 		7B51C5562A61008A0016B418 /* Flag-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Flag-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7B51C5592A61008A0016B418 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7B51C55B2A61008A0016B418 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -166,6 +170,23 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		7B31F7FD2A8E7DE000D7D0CF /* Realm */ = {
+			isa = PBXGroup;
+			children = (
+				7B31F7FE2A8E7E2B00D7D0CF /* RealmDTO */,
+			);
+			path = Realm;
+			sourceTree = "<group>";
+		};
+		7B31F7FE2A8E7E2B00D7D0CF /* RealmDTO */ = {
+			isa = PBXGroup;
+			children = (
+				7B31F7FF2A8E7E6700D7D0CF /* UserFriendListDTO.swift */,
+				7B31F8012A8E7EB900D7D0CF /* testRealmViewController.swift */,
+			);
+			path = RealmDTO;
+			sourceTree = "<group>";
+		};
 		7B51C54D2A61008A0016B418 = {
 			isa = PBXGroup;
 			children = (
@@ -187,6 +208,7 @@
 		7B51C5582A61008A0016B418 /* Flag-iOS */ = {
 			isa = PBXGroup;
 			children = (
+				7B31F7FD2A8E7DE000D7D0CF /* Realm */,
 				7BC45F8D2A8E1A1100EAC144 /* Network */,
 				7BC45F892A8E18B700EAC144 /* Settings */,
 				7B51C5732A6103220016B418 /* Application */,
@@ -610,6 +632,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7B31F8002A8E7E6700D7D0CF /* UserFriendListDTO.swift in Sources */,
 				7B51C5AB2A63F6650016B418 /* BaseTabBarController.swift in Sources */,
 				E547874B2A8AC1920097F2D2 /* FriendListView.swift in Sources */,
 				E53586A42A82019A007D053D /* LoactionView.swift in Sources */,
@@ -643,6 +666,7 @@
 				7B9999222A8ABB2B0043C592 /* UITextView+.swift in Sources */,
 				7B51C5802A6124600016B418 /* TextLiterals.swift in Sources */,
 				7B9998CF2A7A9BEF0043C592 /* SignInViewController.swift in Sources */,
+				7B31F8022A8E7EB900D7D0CF /* testRealmViewController.swift in Sources */,
 				E50CEE492A8768AD00101E4B /* ListViewController.swift in Sources */,
 				7B9998D32A7AA0330043C592 /* SignInView.swift in Sources */,
 				7B9999182A8692780043C592 /* FlagCollectionViewCell.swift in Sources */,

--- a/Flag-iOS/Flag-iOS.xcodeproj/project.pbxproj
+++ b/Flag-iOS/Flag-iOS.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		7B31F7FA2A8E7D8300D7D0CF /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = 7B31F7F92A8E7D8300D7D0CF /* Realm */; };
+		7B31F7FC2A8E7D8300D7D0CF /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 7B31F7FB2A8E7D8300D7D0CF /* RealmSwift */; };
 		7B51C55A2A61008A0016B418 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B51C5592A61008A0016B418 /* AppDelegate.swift */; };
 		7B51C55C2A61008A0016B418 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B51C55B2A61008A0016B418 /* SceneDelegate.swift */; };
 		7B51C5632A61008C0016B418 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7B51C5622A61008C0016B418 /* Assets.xcassets */; };
@@ -154,6 +156,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7B31F7FC2A8E7D8300D7D0CF /* RealmSwift in Frameworks */,
+				7B31F7FA2A8E7D8300D7D0CF /* Realm in Frameworks */,
 				7B51C58B2A61261A0016B418 /* Moya in Frameworks */,
 				7B51C5882A61258B0016B418 /* SnapKit in Frameworks */,
 			);
@@ -544,6 +548,8 @@
 			packageProductDependencies = (
 				7B51C5872A61258B0016B418 /* SnapKit */,
 				7B51C58A2A61261A0016B418 /* Moya */,
+				7B31F7F92A8E7D8300D7D0CF /* Realm */,
+				7B31F7FB2A8E7D8300D7D0CF /* RealmSwift */,
 			);
 			productName = "Flag-iOS";
 			productReference = 7B51C5562A61008A0016B418 /* Flag-iOS.app */;
@@ -576,6 +582,7 @@
 			packageReferences = (
 				7B51C5862A61258B0016B418 /* XCRemoteSwiftPackageReference "SnapKit" */,
 				7B51C5892A61261A0016B418 /* XCRemoteSwiftPackageReference "Moya" */,
+				7B31F7F82A8E7D8300D7D0CF /* XCRemoteSwiftPackageReference "realm-swift" */,
 			);
 			productRefGroup = 7B51C5572A61008A0016B418 /* Products */;
 			projectDirPath = "";
@@ -888,6 +895,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		7B31F7F82A8E7D8300D7D0CF /* XCRemoteSwiftPackageReference "realm-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/realm/realm-swift.git";
+			requirement = {
+				branch = master;
+				kind = branch;
+			};
+		};
 		7B51C5862A61258B0016B418 /* XCRemoteSwiftPackageReference "SnapKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SnapKit/SnapKit.git";
@@ -907,6 +922,16 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		7B31F7F92A8E7D8300D7D0CF /* Realm */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 7B31F7F82A8E7D8300D7D0CF /* XCRemoteSwiftPackageReference "realm-swift" */;
+			productName = Realm;
+		};
+		7B31F7FB2A8E7D8300D7D0CF /* RealmSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 7B31F7F82A8E7D8300D7D0CF /* XCRemoteSwiftPackageReference "realm-swift" */;
+			productName = RealmSwift;
+		};
 		7B51C5872A61258B0016B418 /* SnapKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 7B51C5862A61258B0016B418 /* XCRemoteSwiftPackageReference "SnapKit" */;

--- a/Flag-iOS/Flag-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Flag-iOS/Flag-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -28,6 +28,24 @@
       }
     },
     {
+      "identity" : "realm-core",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/realm/realm-core.git",
+      "state" : {
+        "revision" : "c04f5e401a1ec682e6b08b1ee157e19a0f834a5f",
+        "version" : "13.17.1"
+      }
+    },
+    {
+      "identity" : "realm-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/realm/realm-swift.git",
+      "state" : {
+        "branch" : "master",
+        "revision" : "752f8ae418f97c7e90c2c83ebeeb534c0357df4d"
+      }
+    },
+    {
       "identity" : "rxswift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ReactiveX/RxSwift.git",

--- a/Flag-iOS/Flag-iOS/Application/SceneDelegate.swift
+++ b/Flag-iOS/Flag-iOS/Application/SceneDelegate.swift
@@ -17,7 +17,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let windowScene = (scene as? UIWindowScene) else { return }
         self.window = UIWindow(windowScene: windowScene)
-        let navigationController = UINavigationController(rootViewController: OnboardingViewController())
+        let navigationController = UINavigationController(rootViewController: testRealmViewController())
 
         self.window?.rootViewController = navigationController
         self.window?.makeKeyAndVisible()

--- a/Flag-iOS/Flag-iOS/Realm/RealmDTO/UserFriendListDTO.swift
+++ b/Flag-iOS/Flag-iOS/Realm/RealmDTO/UserFriendListDTO.swift
@@ -1,0 +1,10 @@
+//
+//  UserFriendListDTO.swift
+//  Flag-iOS
+//
+//  Created by 최지우 on 2023/08/18.
+//
+
+import Foundation
+
+import Realm

--- a/Flag-iOS/Flag-iOS/Realm/RealmDTO/testRealmViewController.swift
+++ b/Flag-iOS/Flag-iOS/Realm/RealmDTO/testRealmViewController.swift
@@ -16,8 +16,6 @@ class testRealmViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        print(Realm.Configuration.defaultConfiguration.fileURL!)
-
         let jay = UserFriendList()
         jay.userName = "최지우"
         jay.userId = "jay"
@@ -30,11 +28,12 @@ class testRealmViewController: UIViewController {
             realm.add(jay)
             realm.add(hy)
         }
-//
+
         let savedFriendsList = realm.objects(UserFriendList.self)
         
         view.backgroundColor = .systemBackground
        
+        print(Realm.Configuration.defaultConfiguration.fileURL!)
         print(savedFriendsList)
 //        try! realm.write {
 //            realm.deleteAll()

--- a/Flag-iOS/Flag-iOS/Realm/RealmDTO/testRealmViewController.swift
+++ b/Flag-iOS/Flag-iOS/Realm/RealmDTO/testRealmViewController.swift
@@ -15,6 +15,9 @@ class testRealmViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        view.backgroundColor = .systemBackground
+        
+        // test
         
         let jay = UserFriendList()
         jay.userName = "최지우"
@@ -30,15 +33,7 @@ class testRealmViewController: UIViewController {
         }
 
         let savedFriendsList = realm.objects(UserFriendList.self)
-        
-        view.backgroundColor = .systemBackground
-       
-        print(Realm.Configuration.defaultConfiguration.fileURL!)
         print(savedFriendsList)
-//        try! realm.write {
-//            realm.deleteAll()
-//        }
-        
     }
 }
 

--- a/Flag-iOS/Flag-iOS/Realm/RealmDTO/testRealmViewController.swift
+++ b/Flag-iOS/Flag-iOS/Realm/RealmDTO/testRealmViewController.swift
@@ -1,0 +1,49 @@
+//
+//  testRealmViewController.swift
+//  Flag-iOS
+//
+//  Created by 최지우 on 2023/08/18.
+//
+
+import UIKit
+
+import RealmSwift
+
+class testRealmViewController: UIViewController {
+    
+    let realm = try! Realm()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        print(Realm.Configuration.defaultConfiguration.fileURL!)
+
+        let jay = UserFriendList()
+        jay.userName = "최지우"
+        jay.userId = "jay"
+        
+        let hy = UserFriendList()
+        hy.userName = "성현주"
+        hy.userId = "hy"
+
+        try! realm.write {
+            realm.add(jay)
+            realm.add(hy)
+        }
+//
+        let savedFriendsList = realm.objects(UserFriendList.self)
+        
+        view.backgroundColor = .systemBackground
+       
+        print(savedFriendsList)
+//        try! realm.write {
+//            realm.deleteAll()
+//        }
+        
+    }
+}
+
+class UserFriendList: Object {
+    @objc dynamic var userName: String = ""
+    @objc dynamic var userId: String = ""
+}


### PR DESCRIPTION
## [#65] FEAT : user 친구 추가 목록 localDB 관리하기

## 🌱 what is this PR?

- user의 친구 추가 목록을 localDB를 사용하여 관리합니다.

## 🌱 PR Point

- 아직 서버의 user관련 스키마가 나오지 않아 user정보를 어떻게 관리할 지 몰라 임시로 test 해보았습니다.
- 아래와 같이 `Realm`폴더에서 관리할 예정입니다.
<img width="390" alt="스크린샷 2023-08-18 오후 6 12 42" src="https://github.com/flag-app/Flag-iOS/assets/102797359/5801bdd1-9a01-46bc-9d54-e4e5c28312ff">

- `UserFriendList 객체`를 통해 user의 친구 목록을 관리할 예정입니다. 
 ```
 class UserFriendList: Object {
    @objc dynamic var userName: String = ""
    @objc dynamic var userId: String = ""
}
```
- 임시로 userName과 userId에 더미 값 넣어 realm에 저장되는 것까지 확인했습니다.
<img width="896" alt="스크린샷 2023-08-18 오후 6 16 24" src="https://github.com/flag-app/Flag-iOS/assets/102797359/9b976df8-a945-4c94-9d26-2ec1991e2127">
<br>
<br>
<br>

✅ 다른 작업하다가 추가로 생각난건데, user당 `UserFriendList`객체 하나만 생성하여 공용으로 사용하면 되니까 `싱글톤 패턴` 사용하면 좋지 않을까요?!?
## 📮 관련 이슈

- Resolved: #65 
