### PR TITLE
[REFACTOR] NavigationController와 TabBarController 함께 관리하기(#68)

### DIFF
--- a/Flag-iOS/Flag-iOS/Application/SceneDelegate.swift
+++ b/Flag-iOS/Flag-iOS/Application/SceneDelegate.swift
@@ -17,10 +17,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let windowScene = (scene as? UIWindowScene) else { return }
         self.window = UIWindow(windowScene: windowScene)
-        let navigationController = UINavigationController(rootViewController: testRealmViewController())
 
-        self.window?.rootViewController = navigationController
+        self.window?.rootViewController = BaseTabBarController()
         self.window?.makeKeyAndVisible()
+        
         // 다크 모드 해제
         window?.overrideUserInterfaceStyle = .light
         // navi hidden처리

--- a/Flag-iOS/Flag-iOS/Global/Base/BaseTabBarController.swift
+++ b/Flag-iOS/Flag-iOS/Global/Base/BaseTabBarController.swift
@@ -75,10 +75,11 @@ class BaseTabBarController: UITabBarController {
 
     @objc
     private func didTappedFloatingButton() {
-        let setNameViewController =
-            SetNameViewController()
-        self.navigationController?
-            .pushViewController(setNameViewController, animated: true)
+        let setNameViewController = SetNameViewController()
+        setNameViewController.hidesBottomBarWhenPushed = true
+        if let selectedNavController = self.selectedViewController as? UINavigationController {
+            selectedNavController.pushViewController(setNameViewController, animated: true)
         }
     }
+}
 

--- a/Flag-iOS/Flag-iOS/Global/Base/BaseTabBarController.swift
+++ b/Flag-iOS/Flag-iOS/Global/Base/BaseTabBarController.swift
@@ -35,8 +35,8 @@ class BaseTabBarController: UITabBarController {
         tabBar.backgroundColor = .white
         tabBar.tintColor = .black
         tabBar.itemPositioning = .automatic
-        let viewControllers: [UIViewController] = [flagViewController, myPageViewController]
-        self.setViewControllers(viewControllers, animated: true)
+        let viewControllers: [UIViewController] = [flagNavigationController, myPageNavigationController]
+        self.setViewControllers(viewControllers, animated: false)
     }
     
     private func setViewController() {

--- a/Flag-iOS/Flag-iOS/Global/Base/BaseUIViewController.swift
+++ b/Flag-iOS/Flag-iOS/Global/Base/BaseUIViewController.swift
@@ -37,7 +37,6 @@ class BaseUIViewController: UIViewController {
         navigationController?.navigationBar.tintColor = .black
         navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.font: UIFont.head1]
         let backButton: UIBarButtonItem = UIBarButtonItem()
-//        backButton.title = ""
         navigationController?.navigationBar.topItem?.backBarButtonItem = backButton
     }
     

--- a/Flag-iOS/Flag-iOS/Scenes/Flag/ViewCotrollers/FlagMain/FlagInfoViewController.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Flag/ViewCotrollers/FlagMain/FlagInfoViewController.swift
@@ -18,6 +18,11 @@ class FlagInfoViewController: BaseUIViewController {
         view.backgroundColor = .gray100
     }
     
+    override func setupNavigationBar() {
+        super.setupNavigationBar()
+        navigationItem.title = TextLiterals.flagRawValue
+    }
+    
     override func setUI() {
         view.addSubview(flagInfoView)
     }

--- a/Flag-iOS/Flag-iOS/Scenes/Flag/ViewCotrollers/FlagMain/FlagViewController.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Flag/ViewCotrollers/FlagMain/FlagViewController.swift
@@ -35,7 +35,6 @@ final class FlagViewController: BaseUIViewController {
     override func setupNavigationBar() {
         super.setupNavigationBar()
         navigationItem.title = TextLiterals.flagRawValue
-        navigationController?.navigationBar.topItem?.backBarButtonItem?.isHidden = true
     }
 
     override func setUI() {

--- a/Flag-iOS/Flag-iOS/Scenes/MyPage/ViewControllers/MyPageViewController.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/MyPage/ViewControllers/MyPageViewController.swift
@@ -17,9 +17,12 @@ final class MyPageViewController: BaseUIViewController {
     
     private let mypageView = MyPageView()
     
-    // MARK: - Life Cycle
-    
     // MARK: - Custom Method
+    
+    override func setupNavigationBar() {
+        super.setupNavigationBar()
+        navigationItem.title = TextLiterals.myPage
+    }
     
     override func setUI() {
         view.addSubviews(mypageView)
@@ -62,6 +65,7 @@ extension MyPageViewController: UITableViewDataSource {
         cell.backgroundColor = .white
         cell.accessoryType = .disclosureIndicator
         cell.textLabel?.text = myPageMenu[indexPath.row]
+        cell.textLabel?.font = .title2
         return cell
     }
 }

--- a/Flag-iOS/Flag-iOS/Scenes/MyPage/Views/MyPageView.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/MyPage/Views/MyPageView.swift
@@ -11,9 +11,17 @@ import SnapKit
 
 final class MyPageView: BaseUIView {
     
+    // MARK: - Properties
+    
+    let cellRowHeight: CGFloat = 55
+    
     // MARK: - UI Components
     
-    let tableview = UITableView(frame: .zero, style: .plain)
+    lazy var tableview: UITableView = {
+        let tableView = UITableView(frame: .zero, style: .plain)
+        tableView.rowHeight = cellRowHeight
+        return tableView
+    }()
     
     private let profileImage: UIImageView = {
         let imageView = UIImageView()


### PR DESCRIPTION
## [#68] REFACTOR : NavigationController와 TabBarController 함께 관리하기

## 🌱 what is this PR?

- 현재 NavigationController와 TabBarController가 함께 관리가 안 되고 있는 상황이고,
TabBarController를 rootVC로 설정하여 navigation이 보이지 않는 상황입니다.
뷰 계층에 대한 정리를 진행합니다.

## 🌱 PR Point

- 기존의 tabBar의 VC를 관리하는 코드에서 `NavigationController`를 추가하여 NavigationController를 통한 tabBar관리가 되도록 `SceneDelegate` `BaseTabBarController` 파일을 수정하였습니다. 추후 로그인 여부 판별이 가능해지면, 로그인 판별 후, rootVC를 변경하는 방향으로 코드 수정할 계획입니다.
- 아래는 약속추가 버튼 클릭 했을 때, 실행되는 함수입니다. 
  VC를 푸시하기 위해서는 NavigationController가 필요하고, tabBarController 자체적으로는 NavigationController를 가지고 있지 않기에 FlagVC 혹은 MyPageVC의 NavigationController를 사용하여 뷰컨을 푸시하는 로직입니다. 푸시될 때, tabBar는 보이면 안되기에 `hidesBottomBarWhenPushed`속성을 `true`로 하였습니다.

```
   @objc
    private func didTappedFloatingButton() {
        let setNameViewController = SetNameViewController()
        setNameViewController.hidesBottomBarWhenPushed = true
        if let selectedNavController = self.selectedViewController as? UINavigationController {
            selectedNavController.pushViewController(setNameViewController, animated: true)
        }
    }
```

- 추가로 약속 추가 완료 후, 현재 main으로 푸시가 되는데, 이러한 방식은 메모리가 계속 쌓이게 됩니다! 따라서 약속 추가 완료 버튼 클릭 시, push 방식이 아닌, **`popToRootViewController`** 함수를 통해 이전의 VC들을 pop하여 rootVC가 보이도록 로직 수정부탁드려요!

## 📸 Screenshot

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 네비게이션 | ![ezgif com-video-to-gif (11)](https://github.com/flag-app/Flag-iOS/assets/102797359/c49ec4ad-7986-48de-a12b-ef903097fefb) |


## 📮 관련 이슈

- Resolved: #68 
