### PR TITLE
[FIX] memoTextField TextView로 변경(#75)

### DIFF
--- a/Flag-iOS/Flag-iOS/Global/Literal/TextLiterals.swift
+++ b/Flag-iOS/Flag-iOS/Global/Literal/TextLiterals.swift
@@ -75,6 +75,8 @@ enum TextLiterals {
     static let flagMinTimeTextSix: String = "최소 6시간은 만나야 해요"
     static let flagReadyText: String = "모든 준비가 완료되었어요!\n친구들에게 약속 신청 알림을 보낼까요?"
     static let flagAlarmText: String = "알림 보내기"
+    static let flagOptionText: String = "선택 사항입니다."
+    static let flagPassText: String  = "건너뛰기"
 
 
    

--- a/Flag-iOS/Flag-iOS/Scenes/FlagPlus/ViewControllers/ReadyViewController.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/FlagPlus/ViewControllers/ReadyViewController.swift
@@ -34,8 +34,7 @@ final class ReadyViewController: BaseUIViewController {
     
     @objc
     func didTappedNextButton() {
-        let homeVC = BaseTabBarController()
-        self.navigationController?.pushViewController(homeVC, animated: true)
+        self.navigationController?.popToRootViewController(animated: true)
     }
     
 }

--- a/Flag-iOS/Flag-iOS/Scenes/FlagPlus/Views/LoactionView.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/FlagPlus/Views/LoactionView.swift
@@ -37,14 +37,18 @@ class LoactionView: BaseUIView {
         return label
     }()
     
-    private let memoTextField: BaseUITextField = {
-        let textField = BaseUITextField()
-        return textField
+    private lazy var memoTextView: UITextView = {
+        let textview = UITextView()
+        textview.backgroundColor = .gray100
+        textview.layer.cornerRadius = 9
+        textview.layer.borderWidth = 1.0
+        textview.layer.borderColor = UIColor.gray200.cgColor
+        return textview
     }()
     
     lazy var nextButton: BaseFillButton = {
         let button = BaseFillButton()
-        button.setTitle(TextLiterals.nextText, for: .normal)
+        button.setTitle(TextLiterals.flagPassText, for: .normal)
         button.isEnabled = true
         return button
     }()
@@ -57,15 +61,33 @@ class LoactionView: BaseUIView {
         return view
     }()
     
+    private let optionLabel1: UILabel = {
+        let label = UILabel()
+        label.text = TextLiterals.flagOptionText
+        label.font = .subTitle3
+        label.textColor = .gray400
+        return label
+    }()
+    
+    private let optionLabel2: UILabel = {
+        let label = UILabel()
+        label.text = TextLiterals.flagOptionText
+        label.font = .subTitle3
+        label.textColor = .gray400
+        return label
+    }()
+    
     // MARK: - Custom Method
     
     override func setUI() {
         self.addSubviews(locationLabel,
                          locationTextField,
                          memoLabel,
-                         memoTextField,
+                         memoTextView,
                          nextButton,
-                         progressView)
+                         progressView,
+                         optionLabel1,
+                         optionLabel2)
     }
     
     override func setLayout() {
@@ -74,16 +96,16 @@ class LoactionView: BaseUIView {
             $0.leading.equalToSuperview().offset(25)
         }
         locationTextField.snp.makeConstraints {
-            $0.top.equalTo(locationLabel.snp.bottom).offset(7)
+            $0.top.equalTo(locationLabel.snp.bottom).offset(15)
             $0.horizontalEdges.equalToSuperview().inset(25)
             $0.height.equalTo(41)
         }
         memoLabel.snp.makeConstraints {
-            $0.top.equalTo(locationTextField.snp.bottom).offset(20)
+            $0.top.equalTo(locationTextField.snp.bottom).offset(49)
             $0.leading.equalToSuperview().offset(25)
         }
-        memoTextField.snp.makeConstraints {
-            $0.top.equalTo(memoLabel.snp.bottom).offset(7)
+        memoTextView.snp.makeConstraints {
+            $0.top.equalTo(memoLabel.snp.bottom).offset(15)
             $0.horizontalEdges.equalToSuperview().inset(25)
             $0.height.equalTo(192)
         }
@@ -95,6 +117,14 @@ class LoactionView: BaseUIView {
         progressView.snp.makeConstraints { make in
             make.top.equalTo(safeAreaLayoutGuide).offset(10)
             make.horizontalEdges.equalToSuperview().inset(25)
+        }
+        optionLabel1.snp.makeConstraints { make in
+            make.top.equalTo(locationTextField.snp.bottom).offset(7)
+            make.trailing.equalToSuperview().inset(26)
+        }
+        optionLabel2.snp.makeConstraints { make in
+            make.top.equalTo(memoTextView.snp.bottom).offset(7)
+            make.trailing.equalToSuperview().inset(26)
         }
     }
 }


### PR DESCRIPTION
## [#75] FIX :  memoTextField TextView로 변경

## 🌱 what is this PR?

- "선택사항입니다." 라벨추가
- 버튼 텍스트 "건너뛰기"로 변경
- textField textView로 변경
- popToRootViewController를 통해 plagPlus의 플로우를 정리했습니다

## 🌱 PR Point


## 📸 Screenshot

|    구현 내용    |   
| :-------------: | 
![ezgif com-video-to-gif (10)](https://github.com/flag-app/Flag-iOS/assets/128443511/11844474-b8f9-426e-ba30-317117bf56d8)



## 📮 관련 이슈

- Resolved: #75 
