### PR TITLE
[FEAT] 약속확정시 유저수락상태에 따른 분기처리 API연결, 약속 확정 API연결  

### DIFF
--- a/Flag-iOS/Flag-iOS.xcodeproj/project.pbxproj
+++ b/Flag-iOS/Flag-iOS.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 		E546EF072A93FB4000B59FEA /* UserAcceptStatusResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = E546EF062A93FB4000B59FEA /* UserAcceptStatusResponseDTO.swift */; };
 		E546EF092A94061700B59FEA /* FlagListAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = E546EF082A94061700B59FEA /* FlagListAPI.swift */; };
 		E546EF0B2A94066700B59FEA /* FlagListResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = E546EF0A2A94066700B59FEA /* FlagListResponseDTO.swift */; };
+		E546EF0E2A95138100B59FEA /* FlagCandidateFixDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = E546EF0D2A95138100B59FEA /* FlagCandidateFixDTO.swift */; };
 		E54787432A88CF550097F2D2 /* MyPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E54787422A88CF550097F2D2 /* MyPageView.swift */; };
 		E54787472A88D00D0097F2D2 /* FriendListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E54787462A88D00D0097F2D2 /* FriendListViewController.swift */; };
 		E54787492A88D0160097F2D2 /* TermsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E54787482A88D0160097F2D2 /* TermsViewController.swift */; };
@@ -188,6 +189,7 @@
 		E546EF062A93FB4000B59FEA /* UserAcceptStatusResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAcceptStatusResponseDTO.swift; sourceTree = "<group>"; };
 		E546EF082A94061700B59FEA /* FlagListAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagListAPI.swift; sourceTree = "<group>"; };
 		E546EF0A2A94066700B59FEA /* FlagListResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagListResponseDTO.swift; sourceTree = "<group>"; };
+		E546EF0D2A95138100B59FEA /* FlagCandidateFixDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagCandidateFixDTO.swift; sourceTree = "<group>"; };
 		E54787422A88CF550097F2D2 /* MyPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageView.swift; sourceTree = "<group>"; };
 		E54787462A88D00D0097F2D2 /* FriendListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendListViewController.swift; sourceTree = "<group>"; };
 		E54787482A88D0160097F2D2 /* TermsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsViewController.swift; sourceTree = "<group>"; };
@@ -558,7 +560,6 @@
 				E546EEF92A92ADDC00B59FEA /* FlagProgressDTO */,
 				E546EEF32A9299C200B59FEA /* FlagPlusDTO */,
 				7B31F8062A9275CF00D7D0CF /* AuthDTO */,
-
 			);
 			path = DTO;
 			sourceTree = "<group>";
@@ -664,6 +665,7 @@
 			isa = PBXGroup;
 			children = (
 				E546EF0A2A94066700B59FEA /* FlagListResponseDTO.swift */,
+				E546EF0D2A95138100B59FEA /* FlagCandidateFixDTO.swift */,
 			);
 			path = FlagListDTO;
 			sourceTree = "<group>";
@@ -815,6 +817,7 @@
 				7B9999162A868E640043C592 /* BaseTableViewCell.swift in Sources */,
 				7B31F80A2A927E2F00D7D0CF /* SignUpRequest.swift in Sources */,
 				7B31F8162A93A39100D7D0CF /* AuthRepository.swift in Sources */,
+				E546EF0E2A95138100B59FEA /* FlagCandidateFixDTO.swift in Sources */,
 				7BC45F942A8E1DA500EAC144 /* MoyaLoggerPluggin.swift in Sources */,
 				7B31F8042A923B5600D7D0CF /* UIViewController+.swift in Sources */,
 				7B51C5B52A63F8E70016B418 /* UIView+.swift in Sources */,

--- a/Flag-iOS/Flag-iOS/Application/SceneDelegate.swift
+++ b/Flag-iOS/Flag-iOS/Application/SceneDelegate.swift
@@ -19,7 +19,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         self.window = UIWindow(windowScene: windowScene)
         
         if(realm.checkIsUserSignedIn()) {
-            self.window?.rootViewController = BaseTabBarController()
+            self.window?.rootViewController = ProgressViewController()
         } else {
             self.window?.rootViewController = UINavigationController(rootViewController: OnboardingViewController())
         }

--- a/Flag-iOS/Flag-iOS/Application/SceneDelegate.swift
+++ b/Flag-iOS/Flag-iOS/Application/SceneDelegate.swift
@@ -19,7 +19,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         self.window = UIWindow(windowScene: windowScene)
         
         if(realm.checkIsUserSignedIn()) {
-            self.window?.rootViewController = ProgressViewController()
+            self.window?.rootViewController = BaseTabBarController()
         } else {
             self.window?.rootViewController = UINavigationController(rootViewController: OnboardingViewController())
         }

--- a/Flag-iOS/Flag-iOS/Network/API/FlagListAPI.swift
+++ b/Flag-iOS/Flag-iOS/Network/API/FlagListAPI.swift
@@ -11,6 +11,8 @@ import Moya
 
 enum FlagListAPI {
     case showFlagList(flagId: Int)
+    //리스트에서 확정 api
+    case flagCandidateFix(flagId: Int)
 }
 
 extension FlagListAPI: TargetType {
@@ -22,6 +24,8 @@ extension FlagListAPI: TargetType {
         switch self {
         case .showFlagList(let flagId):
             return "/flag/\(flagId)/candidate"
+        case .flagCandidateFix(let flagId):
+            return "/flag/\(flagId)/candidate/fix"
         }
     }
     
@@ -29,6 +33,8 @@ extension FlagListAPI: TargetType {
         switch self {
         case .showFlagList:
             return .get
+        case .flagCandidateFix:
+            return .post
         }
     }
     
@@ -36,6 +42,8 @@ extension FlagListAPI: TargetType {
         switch self {
         case .showFlagList:
             return .requestPlain
+        case .flagCandidateFix(let body):
+            return .requestJSONEncodable(body)
         }
     }
     

--- a/Flag-iOS/Flag-iOS/Network/DTO/FlagListDTO/FlagCandidateFixDTO.swift
+++ b/Flag-iOS/Flag-iOS/Network/DTO/FlagListDTO/FlagCandidateFixDTO.swift
@@ -1,0 +1,13 @@
+//
+//  FlagCandidateFixDTO.swift
+//  Flag-iOS
+//
+//  Created by 성현주 on 2023/08/23.
+//
+
+import Foundation
+
+struct FlagCandidateFix: Codable {
+    let flagListIndex: Int
+}
+

--- a/Flag-iOS/Flag-iOS/Scenes/Flag/ViewCotrollers/ListViewController.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Flag/ViewCotrollers/ListViewController.swift
@@ -61,6 +61,8 @@ final class ListViewController: BaseUIViewController {
     func didTappedConfirmButton() {
         delegate?.didDismissModal(with: selectedCellIndex)
         dismiss(animated: true, completion: nil)
+        print(selectedCellIndex!)
+        sendFlagListIndexToServer()
     }
 
     @objc
@@ -104,6 +106,29 @@ final class ListViewController: BaseUIViewController {
                             print("Response Parsing Error: \(error)")
                         }
                     
+                    
+                case .failure(let error):
+                    // Handle network error
+                    print("Network Error: \(error)")
+                }
+            }
+        }
+    
+    func sendFlagListIndexToServer() {
+            let provider = MoyaProvider<FlagListAPI>()
+            
+            // Create a FlagPlus object with appropriate data
+            let flagListIndex = FlagCandidateFix(
+                flagListIndex: selectedCellIndex!)
+            
+            // Make the API request
+            provider.request(.flagCandidateFix(flagId: 7)) { result in
+                switch result {
+                case .success(let response):
+                    // Handle successful response
+                    let statusCode = response.statusCode
+                    print("Status Code: \(statusCode)")
+                    // Process the response data as needed
                     
                 case .failure(let error):
                     // Handle network error

--- a/Flag-iOS/Flag-iOS/Scenes/Flag/ViewCotrollers/ProgressViewController.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Flag/ViewCotrollers/ProgressViewController.swift
@@ -45,7 +45,7 @@ final class ProgressViewController: BaseUIViewController {
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        presentModalViewController()
+//        presentModalViewController()
     }
     
     // MARK: - Custom Method
@@ -303,10 +303,22 @@ extension ProgressViewController: UICollectionViewDataSource, UICollectionViewDe
                     // Handle successful response
                     let statusCode = response.statusCode
                         print("Status Code: \(statusCode)")
-                    print(String(data: response.data, encoding: .utf8))
+                    //print(String(data: response.data, encoding: .utf8))
                         // Process the response data as needed
                         do {
-                            _ = try response.map(UserAcceptStatus.self)
+                            let responseData = try JSONDecoder().decode(Bool.self, from: response.data)
+                                print("User Accept Status: \(responseData)")
+                            if responseData {
+                                self.presentModalViewController()
+                                } else {
+                                // The value is false
+                                    self.progressView.modalButton.isHidden = true
+                                    self.progressView.modalButton.removeFromSuperview()
+                                    self.progressView.scrollView.snp.makeConstraints { make in
+                                        make.bottom.equalToSuperview().offset(-20)
+                                    }
+                                    
+                                            }
                         } catch {
                             print("Response Parsing Error: \(error)")
                         }

--- a/Flag-iOS/Flag-iOS/Scenes/Flag/ViewCotrollers/ProgressViewController.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Flag/ViewCotrollers/ProgressViewController.swift
@@ -297,7 +297,7 @@ extension ProgressViewController: UICollectionViewDataSource, UICollectionViewDe
     func userAcceptStatus() {
             let provider = MoyaProvider<FlagProgressAPI>()
         // Make the API request
-            provider.request(.userAcceptStatus(flagId: 7)) { result in
+            provider.request(.userAcceptStatus(flagId: 3)) { result in
                 switch result {
                 case .success(let response):
                     // Handle successful response


### PR DESCRIPTION
## [#86 ] FEAT : 약속확정시 유저수락상태에 따른 분기처리api연결,확정api연결

## 🌱 what is this PR?

- 유저수락상태에따른 분기처리 api를 연결했습니다
- 호스트가 약소을 확정하는 api를 연결했습니다

## 🌱 PR Point

-  테스트를위해 뷰가 예쁘지 않습니다 얼른 기능구현끝내고 뷰 작업시작하겠습니다


## 📸 Screenshot

## 📮 관련 이슈

- Resolved: #86 
