### PR TITLE
[FEAT] api 재호출을 위한 flagTableView의 refresh control 추가 및 AllUsersView 클래스 구현(#91)

### DIFF
--- a/Flag-iOS/Flag-iOS.xcodeproj/project.pbxproj
+++ b/Flag-iOS/Flag-iOS.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		7B31F8292A950FFB00D7D0CF /* FlagMainAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B31F8282A950FFB00D7D0CF /* FlagMainAPI.swift */; };
 		7B31F82C2A951CFE00D7D0CF /* FlagStatusInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B31F82B2A951CFE00D7D0CF /* FlagStatusInfo.swift */; };
 		7B31F82E2A955B2C00D7D0CF /* ProgressFlagListResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B31F82D2A955B2C00D7D0CF /* ProgressFlagListResponse.swift */; };
+		7B31F8302A95CF2000D7D0CF /* AllUsersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B31F82F2A95CF2000D7D0CF /* AllUsersView.swift */; };
 		7B51C55A2A61008A0016B418 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B51C5592A61008A0016B418 /* AppDelegate.swift */; };
 		7B51C55C2A61008A0016B418 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B51C55B2A61008A0016B418 /* SceneDelegate.swift */; };
 		7B51C5632A61008C0016B418 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7B51C5622A61008C0016B418 /* Assets.xcassets */; };
@@ -145,6 +146,7 @@
 		7B31F8282A950FFB00D7D0CF /* FlagMainAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagMainAPI.swift; sourceTree = "<group>"; };
 		7B31F82B2A951CFE00D7D0CF /* FlagStatusInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagStatusInfo.swift; sourceTree = "<group>"; };
 		7B31F82D2A955B2C00D7D0CF /* ProgressFlagListResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressFlagListResponse.swift; sourceTree = "<group>"; };
+		7B31F82F2A95CF2000D7D0CF /* AllUsersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllUsersView.swift; sourceTree = "<group>"; };
 		7B51C5562A61008A0016B418 /* Flag-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Flag-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7B51C5592A61008A0016B418 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7B51C55B2A61008A0016B418 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -694,6 +696,7 @@
 			isa = PBXGroup;
 			children = (
 				7B99991F2A8AB6F50043C592 /* UserProfileView.swift */,
+				7B31F82F2A95CF2000D7D0CF /* AllUsersView.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -908,6 +911,7 @@
 				7B31F80E2A92AC4200D7D0CF /* SignInRequest.swift in Sources */,
 				E546EF132A952A0E00B59FEA /* FriendListDTO.swift in Sources */,
 				7B31F8202A94025300D7D0CF /* GenericResponse.swift in Sources */,
+				7B31F8302A95CF2000D7D0CF /* AllUsersView.swift in Sources */,
 				E535869E2A820175007D053D /* SetNameView.swift in Sources */,
 				E546EF052A93E88100B59FEA /* TermsView.swift in Sources */,
 				7B9999222A8ABB2B0043C592 /* UITextView+.swift in Sources */,

--- a/Flag-iOS/Flag-iOS.xcodeproj/project.pbxproj
+++ b/Flag-iOS/Flag-iOS.xcodeproj/project.pbxproj
@@ -67,7 +67,7 @@
 		7B9999182A8692780043C592 /* FlagCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B9999172A8692780043C592 /* FlagCollectionViewCell.swift */; };
 		7B99991C2A8A85970043C592 /* FlagInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B99991B2A8A85970043C592 /* FlagInfoViewController.swift */; };
 		7B99991E2A8A97680043C592 /* FlagInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B99991D2A8A97680043C592 /* FlagInfoView.swift */; };
-		7B9999202A8AB6F50043C592 /* UserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B99991F2A8AB6F50043C592 /* UserView.swift */; };
+		7B9999202A8AB6F50043C592 /* UserProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B99991F2A8AB6F50043C592 /* UserProfileView.swift */; };
 		7B9999222A8ABB2B0043C592 /* UITextView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B9999212A8ABB2B0043C592 /* UITextView+.swift */; };
 		7BC45F8C2A8E18DF00EAC144 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BC45F8B2A8E18DF00EAC144 /* Config.swift */; };
 		7BC45F942A8E1DA500EAC144 /* MoyaLoggerPluggin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BC45F932A8E1DA500EAC144 /* MoyaLoggerPluggin.swift */; };
@@ -183,7 +183,7 @@
 		7B9999172A8692780043C592 /* FlagCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagCollectionViewCell.swift; sourceTree = "<group>"; };
 		7B99991B2A8A85970043C592 /* FlagInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagInfoViewController.swift; sourceTree = "<group>"; };
 		7B99991D2A8A97680043C592 /* FlagInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagInfoView.swift; sourceTree = "<group>"; };
-		7B99991F2A8AB6F50043C592 /* UserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserView.swift; sourceTree = "<group>"; };
+		7B99991F2A8AB6F50043C592 /* UserProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileView.swift; sourceTree = "<group>"; };
 		7B9999212A8ABB2B0043C592 /* UITextView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextView+.swift"; sourceTree = "<group>"; };
 		7BC45F8B2A8E18DF00EAC144 /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 		7BC45F932A8E1DA500EAC144 /* MoyaLoggerPluggin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoyaLoggerPluggin.swift; sourceTree = "<group>"; };
@@ -610,7 +610,6 @@
 			isa = PBXGroup;
 			children = (
 				7B31F8252A950D5300D7D0CF /* FlagDTO */,
-
 				E546EF262A95476C00B59FEA /* FriendSearchDTO */,
 				E546EF212A95474500B59FEA /* FriendPlusDTO */,
 				E546EF142A95354100B59FEA /* FriendDeleteDTO */,
@@ -639,14 +638,11 @@
 				E546EEFE2A92AED600B59FEA /* FlagProgressAPI.swift */,
 				E546EF082A94061700B59FEA /* FlagListAPI.swift */,
 				7B31F8072A92765F00D7D0CF /* AuthAPI.swift */,
-
 				7B31F8282A950FFB00D7D0CF /* FlagMainAPI.swift */,
-
 				E546EF0F2A9529E700B59FEA /* FriendListAPI.swift */,
 				E546EF172A95359700B59FEA /* FriendDeleteAPI.swift */,
 				E546EF1F2A95473600B59FEA /* FriendPlusAPI.swift */,
 				E546EF242A95476800B59FEA /* FriendSearchAPI.swift */,
-
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -697,7 +693,7 @@
 		E53586AA2A82027C007D053D /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				7B99991F2A8AB6F50043C592 /* UserView.swift */,
+				7B99991F2A8AB6F50043C592 /* UserProfileView.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -894,7 +890,7 @@
 				7B31F8102A92AF4100D7D0CF /* SignInResponse.swift in Sources */,
 				E593AAA72A7E992D00FC918A /* LocationViewController.swift in Sources */,
 				E546EF1C2A9541F500B59FEA /* AddFriendViewController.swift in Sources */,
-				7B9999202A8AB6F50043C592 /* UserView.swift in Sources */,
+				7B9999202A8AB6F50043C592 /* UserProfileView.swift in Sources */,
 				E546EEE12A92485800B59FEA /* NicknameChangeViewController.swift in Sources */,
 				7B9998C12A7A7E9C0043C592 /* OnboardingViewController.swift in Sources */,
 				E546EF012A93A28F00B59FEA /* SelectTimeCellResponseDTO.swift in Sources */,

--- a/Flag-iOS/Flag-iOS/Global/Model/AllUsersView.swift
+++ b/Flag-iOS/Flag-iOS/Global/Model/AllUsersView.swift
@@ -1,0 +1,27 @@
+//
+//  AllUsersView.swift
+//  Flag-iOS
+//
+//  Created by 최지우 on 2023/08/23.
+//
+
+import UIKit
+
+class AllUsersView {
+    
+    /// 인자로 받은 User들의 UserProfileView 반환
+    static func renderStackViewWithUsers(userNames: [String]) -> UIStackView {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.distribution = .fillEqually
+        stackView.spacing = 47
+        
+        for userName in userNames {
+            let userView = UserProfileView(userName: userName)
+            stackView.addArrangedSubview(userView)
+        }
+        
+        return stackView
+    }
+    
+}

--- a/Flag-iOS/Flag-iOS/Global/Model/UserProfileView.swift
+++ b/Flag-iOS/Flag-iOS/Global/Model/UserProfileView.swift
@@ -1,12 +1,12 @@
 //
-//  User.swift
+//  UserProfileView.swift
 //  Flag-iOS
 //
 //  Created by 최지우 on 2023/08/15.
 //
 import UIKit
 
-class UserView: BaseUIView {
+class UserProfileView: BaseUIView {
 
     // MARK: - UI Components
     private let userProfileImage: UIImageView = {

--- a/Flag-iOS/Flag-iOS/Global/Model/UserProfileView.swift
+++ b/Flag-iOS/Flag-iOS/Global/Model/UserProfileView.swift
@@ -9,6 +9,7 @@ import UIKit
 class UserProfileView: BaseUIView {
 
     // MARK: - UI Components
+    
     private let userProfileImage: UIImageView = {
         let imageView = UIImageView()
         imageView.image = ImageLiterals.userProfile

--- a/Flag-iOS/Flag-iOS/Scenes/Flag/ViewCotrollers/FlagMain/FlagViewController.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Flag/ViewCotrollers/FlagMain/FlagViewController.swift
@@ -215,7 +215,12 @@ extension FlagViewController: FlagCollectionViewCellDelegate {
         default:
             break
         }
-        
+    }
+    
+    func didRefreshTable() {
+        getFixedFlag()
+        getProgressFlag()
+        print("api 재호출")
     }
 }
 

--- a/Flag-iOS/Flag-iOS/Scenes/Flag/Views/FlagMain/FlagCollectionViewCell.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Flag/Views/FlagMain/FlagCollectionViewCell.swift
@@ -69,10 +69,6 @@ class FlagCollectionViewCell: BaseCollectionViewCell {
     func initRefresh() {
         refreshControl.addTarget(self, action: #selector(refreshTable(refresh:)), for: .valueChanged)
         
-        refreshControl.backgroundColor = .yellow
-        refreshControl.tintColor = .purple
-        refreshControl.attributedTitle = NSAttributedString(string: "당겨서 새로고침")
-        
         flagTableView.refreshControl = refreshControl
     }
     

--- a/Flag-iOS/Flag-iOS/Scenes/Flag/Views/FlagMain/FlagCollectionViewCell.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Flag/Views/FlagMain/FlagCollectionViewCell.swift
@@ -12,6 +12,7 @@ protocol FlagCollectionViewCellDelegate: AnyObject {
     func numberOfRows(in tableView: UITableView) -> Int
     func cellForRow(at indexPath: IndexPath, in tableView: UITableView, at section: Int) -> UITableViewCell
     func didSelectRowAt(at indexPath: IndexPath, in tableView: UITableView, at section: Int)
+    func didRefreshTable()
 }
 
 class FlagCollectionViewCell: BaseCollectionViewCell {
@@ -77,7 +78,8 @@ class FlagCollectionViewCell: BaseCollectionViewCell {
         print("새로고침 시작")
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-            self.flagTableView.reloadData()
+//            self.flagTableView.reloadData()
+            self.delegate?.didRefreshTable()
             refresh.endRefreshing()
         }
     }

--- a/Flag-iOS/Flag-iOS/Scenes/Flag/Views/FlagMain/FlagCollectionViewCell.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Flag/Views/FlagMain/FlagCollectionViewCell.swift
@@ -30,12 +30,15 @@ class FlagCollectionViewCell: BaseCollectionViewCell {
         return tableView
     }()
     
+    let refreshControl = UIRefreshControl()
+    
     // MARK: - Life Cycle
     
     override init(frame: CGRect) {
         super.init(frame: frame)
         setDelegate()
         setTableView()
+        initRefresh()
     }
     
     required init?(coder: NSCoder) {
@@ -61,6 +64,26 @@ class FlagCollectionViewCell: BaseCollectionViewCell {
     
     func setTableView() {
         flagTableView.register(FlagTableViewCell.self, forCellReuseIdentifier: FlagTableViewCell.identifier)
+    }
+    
+    func initRefresh() {
+        refreshControl.addTarget(self, action: #selector(refreshTable(refresh:)), for: .valueChanged)
+        
+        refreshControl.backgroundColor = .yellow
+        refreshControl.tintColor = .purple
+        refreshControl.attributedTitle = NSAttributedString(string: "당겨서 새로고침")
+        
+        flagTableView.refreshControl = refreshControl
+    }
+    
+    @objc
+    func refreshTable(refresh: UIRefreshControl) {
+        print("새로고침 시작")
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            self.flagTableView.reloadData()
+            refresh.endRefreshing()
+        }
     }
 }
 

--- a/Flag-iOS/Flag-iOS/Scenes/Flag/Views/FlagMain/FlagInfoView.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Flag/Views/FlagMain/FlagInfoView.swift
@@ -49,11 +49,13 @@ class FlagInfoView: BaseUIView {
         return label
     }()
     
-    let userImageView: UserProfileView = {
-        let name = ""
-        let imageView = UserProfileView(userName: name)
-        return imageView
-    }()
+//    let userImageView: UserProfileView = {
+//        let name = ""
+//        let imageView = UserProfileView(userName: name)
+//        return imageView
+//    }()
+    
+    let userImageView = AllUsersView.renderStackViewWithUsers(userNames: ["최지우", "성현주"])
     
     let memoTextView: UITextView = {
         let textView = UITextView()

--- a/Flag-iOS/Flag-iOS/Scenes/Flag/Views/FlagMain/FlagInfoView.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Flag/Views/FlagMain/FlagInfoView.swift
@@ -49,9 +49,9 @@ class FlagInfoView: BaseUIView {
         return label
     }()
     
-    let userImageView: UserView = {
+    let userImageView: UserProfileView = {
         let name = ""
-        let imageView = UserView(userName: name)
+        let imageView = UserProfileView(userName: name)
         return imageView
     }()
     

--- a/Flag-iOS/Flag-iOS/Scenes/Flag/Views/FlagMain/FlagTableViewCell.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Flag/Views/FlagMain/FlagTableViewCell.swift
@@ -121,7 +121,7 @@ class FlagTableViewCell: BaseTableViewCell {
             nameLabel.text = data.name
             dateLabel.text = data.date
             locationLabel.text = data.place
-            participantLabel.text = data.members.joined(separator: ",")
+            participantLabel.text = "\(data.host) 외 \(data.count)명"
             dDayLabel.text = data.dday
         case .progress(let data):
             nameLabel.text = data.name


### PR DESCRIPTION
## [#91] FEAT : api 재호출을 위한 flagTableView의 refresh control 추가

## 🌱 what is this PR?

- api 재호출을 위한 flagTableView의 refresh control 추가하였습니다.
- 참여 인원을 보여주는 `AllUsersView` 구현하였습니다.

## 🌱 PR Point

- 이전에 한 user의 Profile을 생성해주는 `UserProfileView`클래스 구현하였으나, 아래와 같이 여러 user를 보여주어야 하는 경우가 많아 `AllUsersView` 클래스 생성하였습니다. 

<img width="275" alt="스크린샷 2023-08-23 오후 2 52 18" src="https://github.com/flag-app/Flag-iOS/assets/102797359/1a7d13d6-a4b3-4b6d-9971-72239127e90d">

`renderStackViewWithUsers()`에 `userNames`을 인자로 전달 시, 이미지와 같이 user 인원수에 해당하는 `UserProfileView`가 stackView에 담겨 반환됩니다. 따라서 
**`let userStackView = AllUsersView.createStackViewWithUsers(userNames: ["최지우", "성현주"])`** 
위와 같이 stackView 생성하여 사용하시면 됩니다. 
```
class AllUsersView {
    
    /// 인자로 받은 User들의 UserProfileView 반환
    static func renderStackViewWithUsers(userNames: [String]) -> UIStackView {
        let stackView = UIStackView()
        stackView.axis = .horizontal
        stackView.distribution = .fillEqually
        stackView.spacing = 47
        
        for userName in userNames {
            let userView = UserProfileView(userName: userName)
            stackView.addArrangedSubview(userView)
        }
        
        return stackView
    }
    
}
```

## 📸 Screenshot

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| flag 메인 | ![ezgif com-video-to-gif (13)](https://github.com/flag-app/Flag-iOS/assets/102797359/0f485914-91c3-40cf-be78-39fc7619bed8) |

## 📮 관련 이슈

- Resolved: #91 
