### PR TITLE
[FEAT] 친구추가,친구삭제,유저검색API연결 (#94)

### DIFF
--- a/Flag-iOS/Flag-iOS.xcodeproj/project.pbxproj
+++ b/Flag-iOS/Flag-iOS.xcodeproj/project.pbxproj
@@ -102,7 +102,7 @@
 		E546EF1E2A9543B500B59FEA /* AddFriendCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E546EF1D2A9543B500B59FEA /* AddFriendCell.swift */; };
 		E546EF202A95473600B59FEA /* FriendPlusAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = E546EF1F2A95473600B59FEA /* FriendPlusAPI.swift */; };
 		E546EF232A95475600B59FEA /* FriendPlusDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = E546EF222A95475600B59FEA /* FriendPlusDTO.swift */; };
-		E546EF252A95476800B59FEA /* FriendSearchAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = E546EF242A95476800B59FEA /* FriendSearchAPI.swift */; };
+		E546EF252A95476800B59FEA /* FriendsSearchAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = E546EF242A95476800B59FEA /* FriendsSearchAPI.swift */; };
 		E546EF282A95477F00B59FEA /* FriendSerachDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = E546EF272A95477F00B59FEA /* FriendSerachDTO.swift */; };
 		E546EF2A2A954ED400B59FEA /* FriendSearchResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = E546EF292A954ED400B59FEA /* FriendSearchResponseDTO.swift */; };
 		E54787432A88CF550097F2D2 /* MyPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E54787422A88CF550097F2D2 /* MyPageView.swift */; };
@@ -219,7 +219,7 @@
 		E546EF1D2A9543B500B59FEA /* AddFriendCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddFriendCell.swift; sourceTree = "<group>"; };
 		E546EF1F2A95473600B59FEA /* FriendPlusAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendPlusAPI.swift; sourceTree = "<group>"; };
 		E546EF222A95475600B59FEA /* FriendPlusDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendPlusDTO.swift; sourceTree = "<group>"; };
-		E546EF242A95476800B59FEA /* FriendSearchAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendSearchAPI.swift; sourceTree = "<group>"; };
+		E546EF242A95476800B59FEA /* FriendsSearchAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsSearchAPI.swift; sourceTree = "<group>"; };
 		E546EF272A95477F00B59FEA /* FriendSerachDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendSerachDTO.swift; sourceTree = "<group>"; };
 		E546EF292A954ED400B59FEA /* FriendSearchResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendSearchResponseDTO.swift; sourceTree = "<group>"; };
 		E54787422A88CF550097F2D2 /* MyPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageView.swift; sourceTree = "<group>"; };
@@ -610,7 +610,6 @@
 			isa = PBXGroup;
 			children = (
 				7B31F8252A950D5300D7D0CF /* FlagDTO */,
-
 				E546EF262A95476C00B59FEA /* FriendSearchDTO */,
 				E546EF212A95474500B59FEA /* FriendPlusDTO */,
 				E546EF142A95354100B59FEA /* FriendDeleteDTO */,
@@ -639,14 +638,11 @@
 				E546EEFE2A92AED600B59FEA /* FlagProgressAPI.swift */,
 				E546EF082A94061700B59FEA /* FlagListAPI.swift */,
 				7B31F8072A92765F00D7D0CF /* AuthAPI.swift */,
-
 				7B31F8282A950FFB00D7D0CF /* FlagMainAPI.swift */,
-
 				E546EF0F2A9529E700B59FEA /* FriendListAPI.swift */,
 				E546EF172A95359700B59FEA /* FriendDeleteAPI.swift */,
 				E546EF1F2A95473600B59FEA /* FriendPlusAPI.swift */,
-				E546EF242A95476800B59FEA /* FriendSearchAPI.swift */,
-
+				E546EF242A95476800B59FEA /* FriendsSearchAPI.swift */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -949,7 +945,7 @@
 				E54787492A88D0160097F2D2 /* TermsViewController.swift in Sources */,
 				7B9998C32A7A7FEF0043C592 /* OnboardingView.swift in Sources */,
 				E593AA9D2A7E299500FC918A /* FriendsPlusViewController.swift in Sources */,
-				E546EF252A95476800B59FEA /* FriendSearchAPI.swift in Sources */,
+				E546EF252A95476800B59FEA /* FriendsSearchAPI.swift in Sources */,
 				E53586A02A82017E007D053D /* FreindsPlusView.swift in Sources */,
 				E593AAA12A7E2C4D00FC918A /* DatePickViewController.swift in Sources */,
 				7B31F8222A9419AC00D7D0CF /* UIWindow+.swift in Sources */,

--- a/Flag-iOS/Flag-iOS/Global/Literal/TextLiterals.swift
+++ b/Flag-iOS/Flag-iOS/Global/Literal/TextLiterals.swift
@@ -94,7 +94,7 @@ enum TextLiterals {
     //MARK: MyPage
     
     static let searchText: String = "검색"
-    static let DeleteQuestionText: String = "정말 친구 삭제하시겠습니까?"
+    static let DeleteQuestionText: String = "님을 친구 삭제하시겠습니까?"
     static let friendDeleteText: String = "친구삭제"
     static let deleteText: String = "삭제"
     static let newNicknameText: String = "새로운 닉네임을 입력해 주세요."

--- a/Flag-iOS/Flag-iOS/Global/Literal/TextLiterals.swift
+++ b/Flag-iOS/Flag-iOS/Global/Literal/TextLiterals.swift
@@ -100,6 +100,11 @@ enum TextLiterals {
     static let newNicknameText: String = "새로운 닉네임을 입력해 주세요."
     static let newNicknameTextHint: String = "닉네임 최소 2자 ~ 최대 7자"
     static let completeText: String = "완료"
+    static let askFriendPlusText: String = "친구추가하시겠습니까?"
+    static let friendPlusText: String = "추가하기"
+    static let friendListText: String = "친구목록"
+    static let addFriendText: String = "친구추가"
+    
     static let termsText: String = """
     “FLAG” 이용약관
     제1장 총칙

--- a/Flag-iOS/Flag-iOS/Network/API/FriendDeleteAPI.swift
+++ b/Flag-iOS/Flag-iOS/Network/API/FriendDeleteAPI.swift
@@ -10,7 +10,7 @@ import Foundation
 import Moya
 
 enum FriendDeleteAPI {
-    case friendDelete(body: FriendDelete)
+    case friendDelete(body: String)
 }
 
 extension FriendDeleteAPI: TargetType {
@@ -21,7 +21,7 @@ extension FriendDeleteAPI: TargetType {
     var path: String {
         switch self {
         case .friendDelete:
-            return "/friends​/delete"
+            return "/friends/delete"
         }
     }
     
@@ -35,7 +35,7 @@ extension FriendDeleteAPI: TargetType {
     var task: Task {
         switch self {
         case .friendDelete(let body):
-            return .requestJSONEncodable(body)
+            return .requestParameters(parameters: ["name" : body], encoding: URLEncoding.queryString)
         }
     }
     

--- a/Flag-iOS/Flag-iOS/Network/API/FriendPlusAPI.swift
+++ b/Flag-iOS/Flag-iOS/Network/API/FriendPlusAPI.swift
@@ -6,3 +6,46 @@
 //
 
 import Foundation
+
+import Moya
+
+enum FriendPlusAPI {
+    case friendPlus(body: String)
+}
+
+extension FriendPlusAPI: TargetType {
+    public var baseURL: URL {
+            return URL(string: Config.baseURL)!
+        }
+    
+    var path: String {
+        switch self {
+        case .friendPlus:
+            return "/friends/add"
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .friendPlus:
+            return .post
+        }
+    }
+    
+    var task: Task {
+        switch self {
+        case .friendPlus(let body):
+            return .requestParameters(parameters: ["friendName" : body], encoding: URLEncoding.queryString)
+        }
+    }
+    
+    var headers: [String : String]? {
+            return [
+                "Content-type": "application/json",
+                "Authorization":
+                    """
+               eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJvb0BuYXZlci5jb20iLCJyb2xlcyI6W10sImlhdCI6MTY5MjU2Mjc5MywiZXhwIjoxNjk1MTU0NzkzfQ.OadrHpnjbqTCxRSvcSLQyxbJRe49XF-0I7yChSIp6R4
+"""
+            ]
+        }
+}

--- a/Flag-iOS/Flag-iOS/Network/API/FriendsSearchAPI.swift
+++ b/Flag-iOS/Flag-iOS/Network/API/FriendsSearchAPI.swift
@@ -9,33 +9,33 @@ import Foundation
 
 import Moya
 
-enum FriendSearchAPI {
-    case friendSearch(body: FriendSearch)
+enum FriendsSearchAPI {
+    case friendsSearch(body: String)
 }
 
-extension FriendSearchAPI: TargetType {
+extension FriendsSearchAPI: TargetType {
     public var baseURL: URL {
             return URL(string: Config.baseURL)!
         }
     
     var path: String {
         switch self {
-        case .friendSearch:
+        case .friendsSearch:
             return "/friends/List"
         }
     }
     
     var method: Moya.Method {
         switch self {
-        case .friendSearch:
+        case .friendsSearch:
             return .post
         }
     }
     
     var task: Task {
         switch self {
-        case .friendSearch(let body):
-            return .requestJSONEncodable(body)
+        case .friendsSearch(let body):
+            return .requestParameters(parameters: ["name": body], encoding: URLEncoding.queryString)
         }
     }
     

--- a/Flag-iOS/Flag-iOS/Network/DTO/FriendDeleteDTO/FriendDeleteDT0.swift
+++ b/Flag-iOS/Flag-iOS/Network/DTO/FriendDeleteDTO/FriendDeleteDT0.swift
@@ -5,8 +5,8 @@
 //  Created by 성현주 on 2023/08/23.
 //
 
-import Foundation
-
-struct FriendDelete: Codable {
-    let fid: Int
-}
+//import Foundation
+//
+//struct FriendDelete: Codable {
+//    let fid: Int
+//}

--- a/Flag-iOS/Flag-iOS/Network/DTO/FriendPlusDTO/FriendPlusDTO.swift
+++ b/Flag-iOS/Flag-iOS/Network/DTO/FriendPlusDTO/FriendPlusDTO.swift
@@ -6,3 +6,7 @@
 //
 
 import Foundation
+
+struct FriendPlus: Codable {
+    let friendName: String
+}

--- a/Flag-iOS/Flag-iOS/Network/DTO/FriendSearchDTO/FriendSearchResponseDTO.swift
+++ b/Flag-iOS/Flag-iOS/Network/DTO/FriendSearchDTO/FriendSearchResponseDTO.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct UserResponse: Codable {
+struct UserResult: Codable {
     let id: Int
     let name: String
     let email: String
@@ -18,7 +18,7 @@ struct FriendSearchResponse: Codable {
     let code: Int
     let isSuccess: Bool
     let message: String
-    //let result: String
+    let result: String
 }
 
 

--- a/Flag-iOS/Flag-iOS/Scenes/MyPage/ViewControllers/FriendListViewController.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/MyPage/ViewControllers/FriendListViewController.swift
@@ -20,7 +20,6 @@ final class FriendListViewController: BaseUIViewController {
             print("flagListData: \(friendListData)")
         }
     }
-    var userName: String = ""
 
     
     // MARK: - UI Components
@@ -73,9 +72,9 @@ final class FriendListViewController: BaseUIViewController {
         
         let userName = cell.titleLabel.text ?? ""
         
-        let alertView = UIAlertController(title: TextLiterals.DeleteQuestionText, message: "", preferredStyle: .alert)
+        let alertView = UIAlertController(title: "\(userName)\(TextLiterals.DeleteQuestionText)", message: "", preferredStyle: .alert)
         let deleteAction = UIAlertAction(title: TextLiterals.friendDeleteText, style: .default) { _ in
-            self.deleteFriend()
+            self.deleteFriend(userName: userName)
             self.navigationController?.popToRootViewController(animated: true)
         }
         alertView.addAction(deleteAction)
@@ -119,7 +118,7 @@ final class FriendListViewController: BaseUIViewController {
             }
         }
     
-    func deleteFriend() {
+    func deleteFriend(userName: String) {
             let provider = MoyaProvider<FriendDeleteAPI>()
             // Make the API request
             provider.request(.friendDelete(body: userName)) { result in
@@ -153,7 +152,6 @@ extension FriendListViewController: UITableViewDataSource {
         let cell = tableView.dequeueReusableCell(withIdentifier: "FriendListCell", for: indexPath) as! FriendListCell
         
         cell.titleLabel.text = "\(friendListData[indexPath.row].name)"
-        userName = cell.titleLabel.text ?? ""
         cell.subtitleLabel.text = "\(friendListData[indexPath.row].email)"
         cell.deleteButton.addTarget(self, action: #selector(didTappedDeleteButton(_:)), for: .touchUpInside)
         cell.selectionStyle = .none

--- a/Flag-iOS/Flag-iOS/Scenes/MyPage/ViewControllers/FriendListViewController.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/MyPage/ViewControllers/FriendListViewController.swift
@@ -20,6 +20,7 @@ final class FriendListViewController: BaseUIViewController {
             print("flagListData: \(friendListData)")
         }
     }
+    var userName: String = ""
 
     
     // MARK: - UI Components
@@ -31,6 +32,8 @@ final class FriendListViewController: BaseUIViewController {
     override func setUI() {
         view.addSubviews(friendListView)
         getFriendList()
+        let addBarButtonItem = UIBarButtonItem(barButtonSystemItem: .add, target: self, action: #selector(didTappedAddButton))
+            navigationItem.rightBarButtonItem = addBarButtonItem
     }
     
     override func setLayout() {
@@ -47,21 +50,41 @@ final class FriendListViewController: BaseUIViewController {
         friendListView.tableView.dataSource = self
     }
     
+    override func setupNavigationBar() {
+        super.setupNavigationBar()
+        navigationItem.title = TextLiterals.friendListText
+    }
+    
     @objc
     func didTappedFriendSearchButton() {
         print("tap")
     }
+    @objc
+    func didTappedAddButton() {
+        let addFirendViewController = AddFriendViewController()
+        navigationController?.pushViewController(addFirendViewController, animated: true)
+    }
     
     @objc
     func didTappedDeleteButton(_ sender: UIButton) {
+        guard let cell = sender.superview?.superview as? FriendListCell else {
+            return
+        }
+        
+        let userName = cell.titleLabel.text ?? ""
+        
         let alertView = UIAlertController(title: TextLiterals.DeleteQuestionText, message: "", preferredStyle: .alert)
         let deleteAction = UIAlertAction(title: TextLiterals.friendDeleteText, style: .default) { _ in
-                self.deleteFriend() 
-            }
-            alertView.addAction(deleteAction)
+            self.deleteFriend()
+            self.navigationController?.popToRootViewController(animated: true)
+        }
+        alertView.addAction(deleteAction)
+        
         let cancelAction = UIAlertAction(title: TextLiterals.flagCancelText, style: .default, handler: nil)
         alertView.addAction(cancelAction)
+        
         present(alertView, animated: true, completion: nil)
+        print(userName)
     }
     
     //MARK: -NetWork
@@ -98,25 +121,17 @@ final class FriendListViewController: BaseUIViewController {
     
     func deleteFriend() {
             let provider = MoyaProvider<FriendDeleteAPI>()
-            
-            // Create a FriendDelete object with the appropriate data
-            let friendToDelete = FriendDelete(fid: 38) // Replace with the actual friend ID
-            
             // Make the API request
-            provider.request(.friendDelete(body: friendToDelete)) { result in
+            provider.request(.friendDelete(body: userName)) { result in
                 switch result {
                 case .success(let response):
                     // Handle successful response
                     let statusCode = response.statusCode
                     print("Status Code: \(statusCode)")
-                    do {
-                        // Parse the response data if needed
-                        let responseData = try JSONDecoder().decode(FriendDelete.self, from: response.data)
-                        // Perform any actions or UI updates based on the responseData
-                        
-                    } catch {
-                        print("Response Parsing Error: \(error)")
-                    }
+                    let responseData = response.data
+                    if let dataString = String(data: responseData, encoding: .utf8) {
+                    print("Response Data: \(dataString)")
+                                           }
                     
                 case .failure(let error):
                     // Handle network error
@@ -138,6 +153,7 @@ extension FriendListViewController: UITableViewDataSource {
         let cell = tableView.dequeueReusableCell(withIdentifier: "FriendListCell", for: indexPath) as! FriendListCell
         
         cell.titleLabel.text = "\(friendListData[indexPath.row].name)"
+        userName = cell.titleLabel.text ?? ""
         cell.subtitleLabel.text = "\(friendListData[indexPath.row].email)"
         cell.deleteButton.addTarget(self, action: #selector(didTappedDeleteButton(_:)), for: .touchUpInside)
         cell.selectionStyle = .none

--- a/Flag-iOS/Flag-iOS/Scenes/MyPage/Views/FriendListCell.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/MyPage/Views/FriendListCell.swift
@@ -12,6 +12,7 @@ import SnapKit
 class FriendListCell: UITableViewCell {
     
     // MARK: - Properties
+    var userName: String = ""
    
     // MARK: - UI Components
     


### PR DESCRIPTION
## [#97 ] FEAT : 친구추가,친구삭제,유저검색API연결 

## 🌱 what is this PR?

- 친구추가, 친구삭제, 유저검색 api를 연결했습니다

## 🌱 PR Point

- 마이페이지 내친구리스트 테이블뷰 리로드를 위해 루트뷰로 pop하게 했습니다 

## 📸 Screenshot

|    구현 내용    |   
| :-------------: |
![ezgif com-video-to-gif (14)](https://github.com/flag-app/Flag-iOS/assets/128443511/6edcdc43-0f42-4c64-b62e-3a986e12a43f)


## 📮 관련 이슈

- Resolved: #97 
