### PR TITLE
[FEAT] 로그아웃 시, accessToken 제거 및 onboardingVC로 푸시 (#95)

### DIFF
--- a/Flag-iOS/Flag-iOS/Global/Literal/TextLiterals.swift
+++ b/Flag-iOS/Flag-iOS/Global/Literal/TextLiterals.swift
@@ -100,6 +100,9 @@ enum TextLiterals {
     static let newNicknameText: String = "새로운 닉네임을 입력해 주세요."
     static let newNicknameTextHint: String = "닉네임 최소 2자 ~ 최대 7자"
     static let completeText: String = "완료"
+    static let signOutText: String = "로그아웃 하시겠습니까?"
+    static let yesText: String = "예"
+    static let noText: String = "아니오"
     static let termsText: String = """
     “FLAG” 이용약관
     제1장 총칙

--- a/Flag-iOS/Flag-iOS/Scenes/MyPage/ViewControllers/MyPageViewController.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/MyPage/ViewControllers/MyPageViewController.swift
@@ -12,6 +12,7 @@ final class MyPageViewController: BaseUIViewController {
     //MARK: - Properties
     
     let myPageMenu = ["친구 목록" , "이용약관", "로그아웃" , "탈퇴하기" ,"만든 사람들"]
+    let realm = RealmService()
     
     // MARK: - UI Components
     
@@ -51,6 +52,25 @@ final class MyPageViewController: BaseUIViewController {
         navigationController?.pushViewController(termsViewController, animated: true)
     }
     
+    func didTappedSignOutButton() {
+ 
+        let alertView = UIAlertController(title: TextLiterals.signOutText, message: "", preferredStyle: .alert)
+        
+        let deleteAction = UIAlertAction(title: TextLiterals.yesText, style: .default) { _ in
+            // rootView 변경
+            let onboardingViewController = OnboardingViewController()
+            UIApplication.shared.keyWindow?.replaceRootViewController(onboardingViewController, animated: true, completion: nil)
+//            self.navigationController?.popToRootViewController(animated: true)
+            self.realm.deleteAllRealmData()
+        }
+        alertView.addAction(deleteAction)
+        
+        let cancelAction = UIAlertAction(title: TextLiterals.noText, style: .default, handler: nil)
+        alertView.addAction(cancelAction)
+        
+        present(alertView, animated: true, completion: nil)
+    }
+    
 }
 
     //MARK: - TableViewDataSource
@@ -82,7 +102,9 @@ extension MyPageViewController: UITableViewDelegate{
             case 1:
                 let termsViewController = TermsViewController()
                 navigationController?.pushViewController(termsViewController, animated: true)
-//            case 2: // 로그아웃
+            case 2:
+                didTappedSignOutButton()
+                
 //            case 3: // 탈퇴하기
 //.           case 4: // 만든사람들
             default:


### PR DESCRIPTION
## [#95] FEAT : 로그아웃 시, accessToken 제거 및 onboardingVC로 푸시

## 🌱 what is this PR?

- 로그아웃 시, accessToken 제거 및 onboardingVC로 푸시

## 🌱 PR Point

- 로그아웃 시, accessToken 제거 및 onboardingVC로 푸시합니다.

## 📮 관련 이슈

- Resolved: #95 
