### PR TITLE
[FEAT] 마이페이지 닉네임 api 연동 완료 (#105)

### DIFF
--- a/Flag-iOS/Flag-iOS.xcodeproj/project.pbxproj
+++ b/Flag-iOS/Flag-iOS.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		7B51C5B72A6429B00016B418 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B51C5B62A6429B00016B418 /* UIColor+.swift */; };
 		7B8969992A96360700C6DFD6 /* TestTimeScrollViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B8969982A96360700C6DFD6 /* TestTimeScrollViewController.swift */; };
 		7B89699B2A96809B00C6DFD6 /* MyPageAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B89699A2A96809B00C6DFD6 /* MyPageAPI.swift */; };
+		7B89699E2A96844500C6DFD6 /* MyPageResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B89699D2A96844500C6DFD6 /* MyPageResponse.swift */; };
 		7B9998C12A7A7E9C0043C592 /* OnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B9998C02A7A7E9C0043C592 /* OnboardingViewController.swift */; };
 		7B9998C32A7A7FEF0043C592 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B9998C22A7A7FEF0043C592 /* OnboardingView.swift */; };
 		7B9998C52A7A93B30043C592 /* UIButton+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B9998C42A7A93B30043C592 /* UIButton+.swift */; };
@@ -165,6 +166,7 @@
 		7B51C5B62A6429B00016B418 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		7B8969982A96360700C6DFD6 /* TestTimeScrollViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestTimeScrollViewController.swift; sourceTree = "<group>"; };
 		7B89699A2A96809B00C6DFD6 /* MyPageAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageAPI.swift; sourceTree = "<group>"; };
+		7B89699D2A96844500C6DFD6 /* MyPageResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageResponse.swift; sourceTree = "<group>"; };
 		7B9998C02A7A7E9C0043C592 /* OnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewController.swift; sourceTree = "<group>"; };
 		7B9998C22A7A7FEF0043C592 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		7B9998C42A7A93B30043C592 /* UIButton+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+.swift"; sourceTree = "<group>"; };
@@ -517,6 +519,14 @@
 			path = Base;
 			sourceTree = "<group>";
 		};
+		7B89699C2A96842D00C6DFD6 /* MypageDTO */ = {
+			isa = PBXGroup;
+			children = (
+				7B89699D2A96844500C6DFD6 /* MyPageResponse.swift */,
+			);
+			path = MypageDTO;
+			sourceTree = "<group>";
+		};
 		7B9998BD2A7A7E2E0043C592 /* Onboarding */ = {
 			isa = PBXGroup;
 			children = (
@@ -616,6 +626,7 @@
 		7BC45F8E2A8E1A2200EAC144 /* DTO */ = {
 			isa = PBXGroup;
 			children = (
+				7B89699C2A96842D00C6DFD6 /* MypageDTO */,
 				7B31F8252A950D5300D7D0CF /* FlagDTO */,
 				E546EF262A95476C00B59FEA /* FriendSearchDTO */,
 				E546EF212A95474500B59FEA /* FriendPlusDTO */,
@@ -906,6 +917,7 @@
 				E546EF012A93A28F00B59FEA /* SelectTimeCellResponseDTO.swift in Sources */,
 				E5586CEF2A8E68AD00A66EA5 /* FriendsPlusCell.swift in Sources */,
 				E546EEDF2A92484100B59FEA /* NicknameChangeView.swift in Sources */,
+				7B89699E2A96844500C6DFD6 /* MyPageResponse.swift in Sources */,
 				E546EEF52A9299E300B59FEA /* FlagPlusDTO.swift in Sources */,
 				7B9999142A868E2D0043C592 /* FlagTableViewCell.swift in Sources */,
 				7B9998C72A7A95930043C592 /* BaseFillButton.swift in Sources */,

--- a/Flag-iOS/Flag-iOS.xcodeproj/project.pbxproj
+++ b/Flag-iOS/Flag-iOS.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		7B51C5B52A63F8E70016B418 /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B51C5B42A63F8E70016B418 /* UIView+.swift */; };
 		7B51C5B72A6429B00016B418 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B51C5B62A6429B00016B418 /* UIColor+.swift */; };
 		7B8969992A96360700C6DFD6 /* TestTimeScrollViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B8969982A96360700C6DFD6 /* TestTimeScrollViewController.swift */; };
+		7B89699B2A96809B00C6DFD6 /* MyPageAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B89699A2A96809B00C6DFD6 /* MyPageAPI.swift */; };
 		7B9998C12A7A7E9C0043C592 /* OnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B9998C02A7A7E9C0043C592 /* OnboardingViewController.swift */; };
 		7B9998C32A7A7FEF0043C592 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B9998C22A7A7FEF0043C592 /* OnboardingView.swift */; };
 		7B9998C52A7A93B30043C592 /* UIButton+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B9998C42A7A93B30043C592 /* UIButton+.swift */; };
@@ -163,6 +164,7 @@
 		7B51C5B42A63F8E70016B418 /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
 		7B51C5B62A6429B00016B418 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		7B8969982A96360700C6DFD6 /* TestTimeScrollViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestTimeScrollViewController.swift; sourceTree = "<group>"; };
+		7B89699A2A96809B00C6DFD6 /* MyPageAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageAPI.swift; sourceTree = "<group>"; };
 		7B9998C02A7A7E9C0043C592 /* OnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewController.swift; sourceTree = "<group>"; };
 		7B9998C22A7A7FEF0043C592 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		7B9998C42A7A93B30043C592 /* UIButton+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+.swift"; sourceTree = "<group>"; };
@@ -648,6 +650,7 @@
 				E546EF172A95359700B59FEA /* FriendDeleteAPI.swift */,
 				E546EF1F2A95473600B59FEA /* FriendPlusAPI.swift */,
 				E546EF242A95476800B59FEA /* FriendsSearchAPI.swift */,
+				7B89699A2A96809B00C6DFD6 /* MyPageAPI.swift */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -884,6 +887,7 @@
 				7B9998DB2A7C562E0043C592 /* SignUpView.swift in Sources */,
 				7B31F80C2A92A06B00D7D0CF /* SignUpResponse.swift in Sources */,
 				7B51C5852A61249C0016B418 /* UIFont+.swift in Sources */,
+				7B89699B2A96809B00C6DFD6 /* MyPageAPI.swift in Sources */,
 				7B99991C2A8A85970043C592 /* FlagInfoViewController.swift in Sources */,
 				E5DA6F862A83598500FC825F /* ProgressView.swift in Sources */,
 				7B51C5832A61248D0016B418 /* ImageLiterals.swift in Sources */,
@@ -1108,7 +1112,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				BASE_URL = "http://localhost:8080";
+				BASE_URL = "http://13.209.60.211:8080";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = HZ8WU7PA4J;
@@ -1140,7 +1144,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				BASE_URL = "http://localhost:8080";
+				BASE_URL = "http://13.209.60.211:8080";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = HZ8WU7PA4J;

--- a/Flag-iOS/Flag-iOS/Network/API/MyPageAPI.swift
+++ b/Flag-iOS/Flag-iOS/Network/API/MyPageAPI.swift
@@ -6,3 +6,33 @@
 //
 
 import Foundation
+
+import Moya
+
+enum MyPageAPI {
+    case getNickname
+}
+
+extension MyPageAPI: BaseTargetType {
+    
+    var path: String {
+        switch self {
+        case .getNickname:
+            return "/user/mypage"
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .getNickname:
+            return .get
+        }
+    }
+    
+    var task: Task {
+        switch self {
+        case .getNickname:
+            return .requestPlain
+        }
+    }
+}

--- a/Flag-iOS/Flag-iOS/Network/API/MyPageAPI.swift
+++ b/Flag-iOS/Flag-iOS/Network/API/MyPageAPI.swift
@@ -1,0 +1,8 @@
+//
+//  MyPageAPI.swift
+//  Flag-iOS
+//
+//  Created by 최지우 on 2023/08/24.
+//
+
+import Foundation

--- a/Flag-iOS/Flag-iOS/Network/DTO/MypageDTO/MyPageResponse.swift
+++ b/Flag-iOS/Flag-iOS/Network/DTO/MypageDTO/MyPageResponse.swift
@@ -1,0 +1,14 @@
+//
+//  MyPageResponse.swift
+//  Flag-iOS
+//
+//  Created by 최지우 on 2023/08/24.
+//
+
+import Foundation
+
+struct MyPageResponse: Codable {
+    var email: String
+    var friends: [String]
+    var name: String
+}

--- a/Flag-iOS/Flag-iOS/Scenes/MyPage/ViewControllers/MyPageViewController.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/MyPage/ViewControllers/MyPageViewController.swift
@@ -7,18 +7,27 @@
 
 import UIKit
 
+import Moya
+
 final class MyPageViewController: BaseUIViewController {
     
     //MARK: - Properties
     
     let myPageMenu = ["친구 목록" , "이용약관", "로그아웃" , "탈퇴하기" ,"만든 사람들"]
     let realm = RealmService()
+    private let provider = MoyaProvider<MyPageAPI>(plugins: [MoyaLoggerPlugin]())
     
     // MARK: - UI Components
     
     private let mypageView = MyPageView()
     
     // MARK: - Custom Method
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        getNickname()
+        
+    }
     
     override func setupNavigationBar() {
         super.setupNavigationBar()
@@ -113,5 +122,27 @@ extension MyPageViewController: UITableViewDelegate{
         }
     func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         return "앱버전: 1.0.0"
+    }
+}
+
+// MARK: - Network
+
+extension MyPageViewController {
+    
+    private func getNickname() {
+        self.provider.request(.getNickname) { response in
+            switch response {
+            case .success(let moyaResponse):
+                do {
+                    let responseData = try moyaResponse.map(MyPageResponse.self)
+                    print(responseData)
+                    self.mypageView.userNickname = responseData.name
+                } catch (let err) {
+                    print(err.localizedDescription)
+                }
+            case .failure(let err):
+                print(err.localizedDescription)
+            }
+        }
     }
 }

--- a/Flag-iOS/Flag-iOS/Scenes/MyPage/Views/MyPageView.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/MyPage/Views/MyPageView.swift
@@ -14,6 +14,11 @@ final class MyPageView: BaseUIView {
     // MARK: - Properties
     
     let cellRowHeight: CGFloat = 55
+    var userNickname: String = "" {
+        didSet {
+            nameButton.setTitle(userNickname, for: .normal)
+        }
+    }
     
     // MARK: - UI Components
     
@@ -31,7 +36,7 @@ final class MyPageView: BaseUIView {
     
     lazy var nameButton: UIButton = {
         let button = UIButton()
-        button.addTitleAttribute(title: "시리얼>", titleColor: .black, fontName: .title1)
+        button.addTitleAttribute(title: userNickname, titleColor: .black, fontName: .title1)
         return button
     }()
     


### PR DESCRIPTION
## [#105] FEAT : 마이페이지 닉네임 api 연동 완료

## 🌱 what is this PR?

- 마이페이지 닉네임 api 연동 완료하였습니다.

## 🌱 PR Point

- 마이페이지 닉네임 api 연동 완료

## 📸 Screenshot

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 마이페이지 | <img width="374" alt="스크린샷 2023-08-24 오전 3 32 31" src="https://github.com/flag-app/Flag-iOS/assets/102797359/9745cc37-64fa-40da-ba75-a47ee599de56"> |


## 📮 관련 이슈

- Resolved: #105 
