### PR TITLE
[FEAT] 게스트,호스트에따른 progressView 분기처리(#110)

### DIFF
--- a/Flag-iOS/Flag-iOS/Global/Literal/TextLiterals.swift
+++ b/Flag-iOS/Flag-iOS/Global/Literal/TextLiterals.swift
@@ -61,6 +61,7 @@ enum TextLiterals {
     static let flagConfirmText: String = "확인"
     static let flagCancelText: String = "취소"
     static let flagPossibleList: String = "가능한 일정 목록이에요!\n약속을 확정해 주세요."
+    static let flagPossibleTimeList: String = "현재 가능한 시간이에요."
     static let flagMinTimeOne: String = "최소 1시간"
     static let flagMinTimeTextOne: String = "최소 1시간은 만나야 해요"
     static let flagMinTimeTwo: String = "최소 2시간"

--- a/Flag-iOS/Flag-iOS/Scenes/Flag/ViewCotrollers/FlagMain/FlagViewController.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Flag/ViewCotrollers/FlagMain/FlagViewController.swift
@@ -218,6 +218,7 @@ extension FlagViewController: FlagCollectionViewCellDelegate {
             if progressFlagListData[indexPath.section].role == "HOST" {
                 let progressViewController = ProgressViewController()
                 progressViewController.flagId = progressFlagListData[indexPath.section].id
+                progressViewController.role = progressFlagListData[indexPath.section].role
                 progressViewController.hidesBottomBarWhenPushed = true
                 self.navigationController?.pushViewController(progressViewController, animated: true)
             }
@@ -229,6 +230,7 @@ extension FlagViewController: FlagCollectionViewCellDelegate {
                 if progressFlagListData[indexPath.section].check == true {
                     let progressViewController = ProgressViewController()
                     progressViewController.flagId = progressFlagListData[indexPath.section].id
+                    progressViewController.role = progressFlagListData[indexPath.section].role
                     progressViewController.hidesBottomBarWhenPushed = true
                     self.navigationController?.pushViewController(progressViewController, animated: true)
                 } else if progressFlagListData[indexPath.section].check == false {

--- a/Flag-iOS/Flag-iOS/Scenes/Flag/ViewCotrollers/ListViewController.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Flag/ViewCotrollers/ListViewController.swift
@@ -16,6 +16,12 @@ final class ListViewController: BaseUIViewController {
     
     // MARK: - Properties
     
+    var flagId: Int = 0 {
+        didSet {
+            print("♥️\(flagId)listview")
+        }
+    }
+    
     var selectedCellIndex: Int? = nil
     weak var delegate: ListViewControllerDelegate?
     var numberFlagList: Int = 0
@@ -87,7 +93,7 @@ final class ListViewController: BaseUIViewController {
             let provider = MoyaProvider<FlagListAPI>()
             
         // Make the API request
-        provider.request(.showFlagList(flagId: progressViewController.flagId)) { result in
+        provider.request(.showFlagList(flagId: 63)) { result in
                 switch result {
                 case .success(let response):
                     // Handle successful response
@@ -119,9 +125,11 @@ final class ListViewController: BaseUIViewController {
             
             // Create a FlagPlus object with appropriate data
             let flagListIndex =  selectedCellIndex!
+        print("=========================")
+        print(progressViewController.flagId)
             
             // Make the API request
-        provider.request(.flagCandidateFix(flagId: progressViewController.flagId, requestBody: flagListIndex)) { result in
+        provider.request(.flagCandidateFix(flagId: 63, requestBody: selectedCellIndex!)) { result in
             switch result {
             case .success(let response):
                 // Handle successful response

--- a/Flag-iOS/Flag-iOS/Scenes/Flag/ViewCotrollers/ProgressViewController.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Flag/ViewCotrollers/ProgressViewController.swift
@@ -19,6 +19,11 @@ final class ProgressViewController: BaseUIViewController {
             print("♥️\(flagId)")
         }
     }
+    var role: String = "" {
+        didSet {
+            print("⭐️\(role)")
+        }
+    }
     var selectedDates: [Date] = []
     var array = [1]
     var selcetedTime: Int = 1
@@ -61,6 +66,7 @@ final class ProgressViewController: BaseUIViewController {
         selectedDates.sort()
         view.addSubviews(progressView)
 //        categorizeNumbers()
+        divideHG()
     }
     
     override func setLayout() {
@@ -79,8 +85,6 @@ final class ProgressViewController: BaseUIViewController {
         progressView.collectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: "Cell")
     }
     
-   
-    
     @objc
     func didTappedNextButton() {
         let homeVC = BaseTabBarController()
@@ -92,6 +96,16 @@ final class ProgressViewController: BaseUIViewController {
         presentModal()
     }
     
+    func divideHG() {
+        if role == "GUEST"{
+            self.progressView.modalButton.isHidden = true
+            //presentModalViewController() = false
+            self.progressView.modalButton.removeFromSuperview()
+            self.progressView.scrollView.snp.makeConstraints { make in
+                make.bottom.equalToSuperview().offset(-20)
+            }
+        }
+    }
     
     func presentModal(){
         let vc = ListViewController()
@@ -258,7 +272,6 @@ extension ProgressViewController: UICollectionViewDataSource, UICollectionViewDe
                 }
                 
                 selectedDates = dateArray // 변환된 날짜 배열 출력
-                //selectedDates.sort()
             }
             categorizeNumbers()
             allUserNumber = responseData.userTotalCount
@@ -314,17 +327,20 @@ extension ProgressViewController: UICollectionViewDataSource, UICollectionViewDe
                         do {
                             let responseData = try JSONDecoder().decode(Bool.self, from: response.data)
                                 print("User Accept Status: \(responseData)")
-                            if responseData {
-                                self.presentModalViewController()
+                            if self.role == "HOST" {
+                                if responseData {
+                                    self.presentModalViewController()
                                 } else {
-                                // The value is false
+                                    // The value is false
                                     self.progressView.modalButton.isHidden = true
                                     self.progressView.modalButton.removeFromSuperview()
                                     self.progressView.scrollView.snp.makeConstraints { make in
                                         make.bottom.equalToSuperview().offset(-20)
                                     }
                                     
-                                            }
+                                }
+                            }
+                            
                         } catch {
                             print("Response Parsing Error: \(error)")
                         }

--- a/Flag-iOS/Flag-iOS/Scenes/Flag/Views/ProgressView.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Flag/Views/ProgressView.swift
@@ -21,7 +21,7 @@ final class ProgressView: BaseUIView {
     
     private let timeLabel: UILabel = {
         let label = UILabel()
-        label.text = TextLiterals.flagPossibleList
+        label.text = TextLiterals.flagPossibleTimeList
         label.font = .title1
         label.numberOfLines = 0
         return label


### PR DESCRIPTION
## [#110 ] FEAT : 게스트,호스트에따른 progressView분기처리

## 🌱 what is this PR?

- 게스트,호스트에따른 progressView분기처리

## 🌱 PR Point

- ListViewController에도 flagId가 들어와야할것 같습니다. progressView의 것을 접근해서 사용이 안됩니다
- 날짜 정렬에 관해 문제가있는거 같습니다 서버에서는 정렬이 안되어 들어오고있어서 이부분 확인해야될거 같습니다

## 📸 Screenshot

|    구현 내용    |  
| :-------------: | 
![ezgif com-video-to-gif (16)](https://github.com/flag-app/Flag-iOS/assets/128443511/631ceb69-238c-49a0-a794-60faec6aabee)

## 📮 관련 이슈

- Resolved: #110 
