### PR TITLE
[FIX] 회원가입 로직 수정 (#118)

### DIFF
--- a/Flag-iOS/Flag-iOS/Application/SceneDelegate.swift
+++ b/Flag-iOS/Flag-iOS/Application/SceneDelegate.swift
@@ -15,7 +15,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
 
-//        realm.deleteAllRealmData()
+        realm.deleteAllRealmData()
         guard let windowScene = (scene as? UIWindowScene) else { return }
         self.window = UIWindow(windowScene: windowScene)
         

--- a/Flag-iOS/Flag-iOS/Network/API/AuthAPI.swift
+++ b/Flag-iOS/Flag-iOS/Network/API/AuthAPI.swift
@@ -14,11 +14,8 @@ enum AuthAPI {
     case signIn(body: SignInRequest)
 }
 
-extension AuthAPI: TargetType {
-    public var baseURL: URL {
-        return URL(string: Config.baseURL)!
-    }
-    
+extension AuthAPI: BaseTargetType {
+
     var path: String {
         switch self {
         case .signUp:

--- a/Flag-iOS/Flag-iOS/Network/DTO/AuthDTO/SignUpRequest.swift
+++ b/Flag-iOS/Flag-iOS/Network/DTO/AuthDTO/SignUpRequest.swift
@@ -11,12 +11,5 @@ struct SignUpRequest: Codable {
     var email: String
     var name: String
     var password: String
-    var profile: String
     
-    init(_ email: String, _ name: String, _ password: String) {
-        self.email = email
-        self.name = name
-        self.password = password
-        self.profile = ""
-    }
 }

--- a/Flag-iOS/Flag-iOS/Scenes/Onboarding/ViewControllers/SignUpViewController.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Onboarding/ViewControllers/SignUpViewController.swift
@@ -48,8 +48,8 @@ class SignUpViewController: BaseUIViewController {
     @objc
     func didTappedNextButton() {
         postSignUpRequest(userEmail: signUpView.emailTextField.text!,
-                          userPassword: signUpView.passwordTextField.text!,
-                          userNickname: signUpView.nicknameTextField.text!)
+                          userNickname: signUpView.nicknameTextField.text!,
+                          userPassword: signUpView.passwordTextField.text!)
       
         self.navigationController?.popViewController(animated: true)
     }
@@ -58,8 +58,8 @@ class SignUpViewController: BaseUIViewController {
 // MARK: - Network
 
 extension SignUpViewController {
-    func postSignUpRequest(userEmail: String, userPassword: String, userNickname: String) {
-        let param = SignUpRequest(userEmail, userPassword, userNickname)
+    func postSignUpRequest(userEmail: String, userNickname: String, userPassword: String) {
+        let param = SignUpRequest(email: userEmail, name: userNickname, password: userPassword)
         
         self.authProvider.request(.signUp(body: param)) { response in
             switch response {


### PR DESCRIPTION
## [#118] FIX : 회원가입 로직 수정

## 🌱 what is this PR?

- 현재 회원가입 시, 부분적으로 회원가입이 안되는 경우가 생겨 이를 해결하였습니다.

## 🌱 PR Point

- 회원가입 로직을 보니, 닉네임과 비밀번호 순서가 바뀌어 회원가입이 되고 있었네요...ㅎ 수정하였습니다.
- 위의 에러를 수정하면서 코드 리팩터링도 같이 진행하였습니다.
     - 아래의 기존 코드를 보면 `profile`에 빈 스트링 문자열을 서버에 보내기 위해 `init`을 사용하였으나, 오늘 다시 스키마를 보니 `profile`매개 변수가 아예 삭제되어 있어 `init`함수 제거하고, `SignUpRequest`구조체가 필요한 곳에서 바로 초기화해주었습니다.
     ```
      struct SignUpRequest: Codable {
          var email: String
          var name: String
          var password: String
          var profile: String
      
          init(_ email: String, _ name: String, _ password: String) {
              self.email = email
              self.name = name
              self.password = password
              self.profile = ""
          }
      }
     ```
     - `AuthAPI`이 `BaseTargetType`상속받도록 하였습니다.

## 📸 Screenshot

서버 DB로 유저 회원가입 완료되는 것 확인했습니다!
<img width="827" alt="스크린샷 2023-08-29 오후 10 56 48" src="https://github.com/flag-app/Flag-iOS/assets/102797359/66a07a17-3df2-4606-bc0e-b483f3f2e85e">


## 📮 관련 이슈

- Resolved: #118 
