### PR TITLE
[Fix]직접입력 버그해결 + 약속리스트 없을떄 alertView추가 (#125)

### DIFF
--- a/Flag-iOS/Flag-iOS/Application/SceneDelegate.swift
+++ b/Flag-iOS/Flag-iOS/Application/SceneDelegate.swift
@@ -15,7 +15,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
 
-        realm.deleteAllRealmData()
+        //realm.deleteAllRealmData()
         guard let windowScene = (scene as? UIWindowScene) else { return }
         self.window = UIWindow(windowScene: windowScene)
         

--- a/Flag-iOS/Flag-iOS/Global/Literal/TextLiterals.swift
+++ b/Flag-iOS/Flag-iOS/Global/Literal/TextLiterals.swift
@@ -92,7 +92,11 @@ enum TextLiterals {
     static let flagAcceptUsersText: String = "현재 약속을 수락한 친구들"
     static let flagNonResponseUsersText: String = "아직 응답이 없는 친구들"
     static let flagPrimaryUserText: String = "0명\n가능"
-    
+    static let flagNonExistText: String = "가능한 FLAG가 없어요🥺"
+    static let flagBackHomeText: String = "홈으로"
+    static let flagBackProgressText: String = "현황보기"
+
+
     
     //MARK: MyPage
     

--- a/Flag-iOS/Flag-iOS/Scenes/Flag/ViewCotrollers/ListViewController.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/Flag/ViewCotrollers/ListViewController.swift
@@ -107,6 +107,22 @@ final class ListViewController: BaseUIViewController {
                             print(self.numberFlagList)
                             self.flagListData = responseData
                             
+                            if responseData.isEmpty {
+                                let alertView = UIAlertController(title: "\(TextLiterals.flagNonExistText)", message: "", preferredStyle: .alert)
+                                let deleteAction = UIAlertAction(title: TextLiterals.flagBackHomeText, style: .default) { [self] _ in
+                                    delegate?.didDismissModal(with: -1)
+                                    dismiss(animated: true, completion: nil)
+                                }
+                                alertView.addAction(deleteAction)
+                                
+                                let cancelAction = UIAlertAction(title: TextLiterals.flagBackProgressText, style: .default){_ in
+                                    self.dismiss(animated: true, completion: nil)
+                                }
+                                alertView.addAction(cancelAction)
+                                
+                                self.present(alertView, animated: true, completion: nil)
+                                
+                            }
                             self.listView.tableView.reloadData()
                         } catch {
                             print("Response Parsing Error: \(error)")
@@ -185,14 +201,6 @@ extension ListViewController: UITableViewDataSource {
         }
         return cell
     }
-    
-//    func numberOfSections(in tableView: UITableView) -> Int {
-//        return sections.count
-//    }
-//
-//    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-//        return sections[section]
-//    }
 }
 
 extension ListViewController: UITableViewDelegate {

--- a/Flag-iOS/Flag-iOS/Scenes/FlagPlus/Views/DatePickView.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/FlagPlus/Views/DatePickView.swift
@@ -223,8 +223,11 @@ final class DatePickView: BaseUIView {
             } else {
                 self.selectedTime = -1
             }
+            self.minTimePopButton.isEnabled = true
             let endtime = self.selectedTime + 5
-            self.displayLabel.text = "\(self.selectedTime):00 ~ \(endtime):59"
+            let timeInterval = "\(self.selectedTime):00 ~ \(endtime):59"
+            self.displayLabel.text = timeInterval
+            self.timeText = timeInterval
         }
         let cancelAction = UIAlertAction(title: TextLiterals.flagCancelText, style: .cancel, handler: nil)
         alertController.addAction(confirmAction)

--- a/Flag-iOS/Flag-iOS/Scenes/FlagPlus/Views/LoactionView.swift
+++ b/Flag-iOS/Flag-iOS/Scenes/FlagPlus/Views/LoactionView.swift
@@ -37,7 +37,7 @@ class LoactionView: BaseUIView {
         return label
     }()
     
-     lazy var memoTextView: UITextView = {
+    lazy var memoTextView: UITextView = {
         let textview = UITextView()
         textview.backgroundColor = .gray100
         textview.layer.cornerRadius = 9
@@ -48,7 +48,7 @@ class LoactionView: BaseUIView {
     
     lazy var nextButton: BaseFillButton = {
         let button = BaseFillButton()
-        button.setTitle(TextLiterals.flagPassText, for: .normal)
+        button.setTitle(TextLiterals.nextText, for: .normal)
         button.isEnabled = true
         return button
     }()


### PR DESCRIPTION
## [#125] FIX: 직접입력 버그해결 + 약속리스트 없을떄 alertView추가

## 🌱 what is this PR?

- 기존에 직접입력이 안되던 버그를 해결했습니다
- 약속리스트가 없을때 사용자가 인지할수있게금 alertView를 추가했습니다
- locationView(선택사항뷰)에서 버튼의 텍스트를 "다음"으로 변경했습니다

## 🌱 PR Point

- 직접입력이 안되던 버그는 mintimePopButton의 비활성화를 해제를 안시켜서 생겼던 오류였습니다. 비활성화를 해제하는 코드를 추가해 해결하였고, 디스플레이라벨에서 시간의 간격이 보여지는 부분까지 구현했습니다. 그부분에 대해 설명하자면, 시간대popButton이 작동하는 방식이 시간이 선택이 되어지면 UIAction으로 
```swift
 func selectTimeAction(_ time: Int, _ label: String) -> UIActionHandler {
        return { [weak self] _ in
            self?.selectedTime = time
            self?.displayLabel.text = label
            self?.displayLabel.font = .head1
            self?.timeText = label
            self?.minTimePopButton.isEnabled = true
        }
    }
``` 
이런 함수가 호출이 되고 timeText에 디스플레이 라벨에서 보여주기위한 텍스트, 예를들어 오전,오후 와 같은 텍스트를 timeText라는 변수에 넣어서 관리했고,  timeText를 디스플레이라벨에서 보여주는식으로 작동했습니다.  그러나 직접입력부분의 기존코드에서는 직접입력시에 timeText변수에 넣어서 관리가 안되고 그냥 시간간격을 보여주는 형식이이서 timeInterval이라는 변수를 생성해 시간간격텍스트를 관리하였고 timeInterval을 timeText에 추가해 전역으로 관리되게 끔 만들었습니다
```swift
self.minTimePopButton.isEnabled = true
            let endtime = self.selectedTime + 5
            let timeInterval = "\(self.selectedTime):00 ~ \(endtime):59"
            self.displayLabel.text = timeInterval
            self.timeText = timeInterval
``` 
코드로 보면 이렇습니다!

- 약속리스트가 없을때 사용자가 리스트가 없음을 인지하게끔 alertView를 추가했습니다. 테스트를 하면서 약속리스트가 없는 상황인지, 뭔가 오류가 생긴것인지 명확하지 않을때가 있어서 사용성이 떨어질거를 고려해 추가했습니다. 모달에서 선택된 플래그 셀의 인덱스를 뷰컨트롤러로 보내기위한 delegate함수를 재사용하여 구현했습니다 
```swift
extension ProgressViewController: ListViewControllerDelegate {
    func didDismissModal(with information: Int?) {
        if let info = information {
            print("모달로부터 전달된 리스트: \(info)")
        }
        //살짝 에니메이션
        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
            let homeVC = BaseTabBarController()
            //self.navigationController?.pushViewController(homeVC, animated: true)
            self.navigationController?.popToRootViewController(animated: true)
        }
    }
}
```
처음 개발할때 이 델리게이트를 고안한게 listViewController가  progressViewController에서  띄워진것이라 listViewController에서 루트뷰로 곧바로 pop이 안되었고 pop을 하기 위해 상위뷰컨인 progressViewController에서 pop을 하기위한 델리게이트였는데 alertView에서 "홈으로"라는 버튼을 눌렀을때 루트뷰로 pop이 안되는 동일한 문제를 겪어 해결하기 위해 재사용했습니다. 그과정에서 생긴 문제점으론 원래 didDismissModal() information부분에 셀 인덱스값이 들어가야하는데 플래그가 없는 상황에서는 셀이 없고 그로인해 인덱스값이 없어서 임의로 -1 을 추가했습니다. 스웨거와 여러테스트를 통해 flagStatus에 문제가 없는부분을 확인했습니다!

- locationView(선택사항뷰)에서 버튼의 텍스트를 "다음"으로 변경했습니다. 원래 locationTextfield와 memoTextView둘중 하나라도 값이 변경되면 버튼의 텍스트를 "건너뛰기"에서 "다음"으로 변경하려 했으나 textView가 view여서 addTarget이 안되서... 실패했습니다.. delegate를 이용해 textView의 값이 변경될때마다 처리를 해줄려했으나 실패했습니다...ㅠㅠ 그래서 고통받고있을때 스크럼때 해주신 이야기바탕으로 버튼의 텍스트를 변경하는걸로 합의봤습니다. 시간적여유가 더생기면 다시한번 도전에 성공시켜놓겠습니다!!🔥

## 📸 Screenshot

|    구현 내용    |   
| :-------------: | 
![ezgif com-video-to-gif (18)](https://github.com/flag-app/Flag-iOS/assets/128443511/ae55ef9b-63be-4fd1-9c13-1ae60db7a1b9)


## 📮 관련 이슈

- Resolved: #125
